### PR TITLE
Fix audit findings: data integrity, path handling, and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +488,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "glob",
  "indexmap",
  "quick-xml",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sf-compact"
 version = "0.1.0"
 edition = "2021"
-description = "Convert Salesforce metadata XML to AI-friendly YAML and back. Lossless roundtrip."
+description = "Convert Salesforce metadata XML to AI-friendly YAML and back. Semantically lossless roundtrip."
 license = "MIT"
 repository = "https://github.com/vradko/sf-compact"
 homepage = "https://github.com/vradko/sf-compact"
@@ -19,6 +19,7 @@ walkdir = "2"
 anyhow = "1"
 indexmap = { version = "2", features = ["serde"] }
 tiktoken-rs = "0.9.1"
+glob = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sf-compact
 
-Convert Salesforce metadata XML to AI-friendly YAML and back. Lossless roundtrip.
+Convert Salesforce metadata XML to AI-friendly YAML and back. Semantically lossless roundtrip.
 
 Salesforce metadata XML is extremely verbose — profiles, permission sets, flows, and objects can be 20,000–50,000+ lines of XML with 70–85% structural overhead. This burns tokens and money when AI tools (Claude Code, Codex, Cursor, etc.) read or edit your metadata.
 
@@ -81,7 +81,7 @@ sf-compact pack force-app --include "*.profile-meta.xml"
 sf-compact unpack [source...] [-o output]
 ```
 
-Convert compact YAML back to Salesforce metadata XML (lossless).
+Convert compact YAML back to Salesforce metadata XML (semantically lossless).
 
 ```bash
 sf-compact unpack .sf-compact -o force-app
@@ -152,7 +152,7 @@ sf-compact manifest
 
 ## Supported Metadata Types
 
-43 Salesforce metadata types across 7 categories:
+46 file extensions mapping to 41 unique Salesforce metadata types across 7 categories:
 
 | Category | Types |
 |----------|-------|
@@ -180,7 +180,8 @@ sf-compact manifest
 - Groups repeated elements (e.g., `<fieldPermissions>`) into YAML arrays
 - Coerces types: `"true"` → `true`, `"59.0"` → `59.0`
 - Flattens simple key-value containers into inline YAML mappings
-- Preserves namespaces, attributes, and all structural information for lossless roundtrip
+- Preserves namespaces, attributes, and all structural information for semantically lossless roundtrip
+- **Note:** element ordering within a parent may change. Salesforce metadata API does not guarantee element order, so this is semantically equivalent
 
 Token counting uses the `cl100k_base` tokenizer (same family used by GPT-4 and Claude).
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -186,26 +186,23 @@ fn find_sf_xml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
     files
 }
 
+fn is_sf_compact_yaml(path: &Path) -> bool {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    name.ends_with("-meta.yaml")
+}
+
 fn find_yaml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
     for path in &opts.paths {
         if path.is_file() {
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if ext == "yaml" || ext == "yml" {
+            if is_sf_compact_yaml(path) {
                 files.push(path.clone());
             }
         } else if path.is_dir() {
             for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
-                if entry.file_type().is_file() {
-                    let ext = entry
-                        .path()
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .unwrap_or("");
-                    if ext == "yaml" || ext == "yml" {
-                        files.push(entry.path().to_path_buf());
-                    }
+                if entry.file_type().is_file() && is_sf_compact_yaml(entry.path()) {
+                    files.push(entry.path().to_path_buf());
                 }
             }
         }
@@ -221,27 +218,31 @@ fn find_yaml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
     files
 }
 
-/// Simple glob matching: supports * and ** patterns.
+/// Glob matching using the `glob` crate's Pattern.
 fn glob_match(pattern: &str, path: &str) -> bool {
-    // Simple: check if pattern appears as substring, or do basic wildcard
-    if pattern.contains('*') {
-        // Convert glob to simple check: "profiles/**" → contains "profiles/"
-        let prefix = pattern.trim_end_matches("/**").trim_end_matches("/*");
-        if prefix != pattern {
-            return path.contains(prefix);
+    let options = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: false,
+        require_literal_leading_dot: false,
+    };
+    match glob::Pattern::new(pattern) {
+        Ok(p) => {
+            // Try matching against the full path and also just the filename
+            p.matches_with(path, options)
+                || Path::new(path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| p.matches_with(name, options))
         }
-        // "*.profile-meta.xml" → ends with ".profile-meta.xml"
-        let suffix = pattern.trim_start_matches('*');
-        if suffix != pattern {
-            return path.ends_with(suffix);
-        }
+        Err(_) => path.contains(pattern),
     }
-    // Fallback: substring match
-    path.contains(pattern)
 }
 
 /// Determine the common root directory from opts for relative path display.
 fn common_root(opts: &ConvertOpts) -> PathBuf {
+    if opts.paths.is_empty() {
+        return PathBuf::from(".");
+    }
     if opts.paths.len() == 1 {
         let p = &opts.paths[0];
         if p.is_dir() {
@@ -249,13 +250,65 @@ fn common_root(opts: &ConvertOpts) -> PathBuf {
         }
         return p.parent().unwrap_or(p).to_path_buf();
     }
-    PathBuf::from(".")
+    // Find longest common ancestor of all paths
+    let dirs: Vec<PathBuf> = opts
+        .paths
+        .iter()
+        .map(|p| {
+            let abs = if p.is_absolute() {
+                p.clone()
+            } else {
+                std::env::current_dir().unwrap_or_default().join(p)
+            };
+            if abs.is_dir() {
+                abs
+            } else {
+                abs.parent().unwrap_or(&abs).to_path_buf()
+            }
+        })
+        .collect();
+
+    let first: Vec<_> = dirs[0].components().collect();
+    let mut prefix_len = first.len();
+    for path in &dirs[1..] {
+        let comps: Vec<_> = path.components().collect();
+        prefix_len = prefix_len.min(
+            first
+                .iter()
+                .zip(comps.iter())
+                .take_while(|(a, b)| a == b)
+                .count(),
+        );
+    }
+    if prefix_len == 0 {
+        return PathBuf::from("/");
+    }
+    first[..prefix_len].iter().collect()
+}
+
+/// Compute relative path safely, falling back to filename if strip_prefix fails.
+fn safe_relative(path: &Path, root: &Path) -> PathBuf {
+    path.strip_prefix(root)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| {
+            // Try with canonicalized paths
+            let canon_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            let canon_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+            canon_path
+                .strip_prefix(&canon_root)
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|_| {
+                    // Last resort: use just the filename
+                    path.file_name()
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| path.to_path_buf())
+                })
+        })
 }
 
 fn yaml_path_for_xml(xml_path: &Path, source_root: &Path, output_root: &Path) -> PathBuf {
-    let relative = xml_path.strip_prefix(source_root).unwrap_or(xml_path);
+    let relative = safe_relative(xml_path, source_root);
     let mut out = output_root.join(relative);
-    // Replace .xml extension with .yaml
     let name = out
         .file_name()
         .and_then(|n| n.to_str())
@@ -266,7 +319,7 @@ fn yaml_path_for_xml(xml_path: &Path, source_root: &Path, output_root: &Path) ->
 }
 
 fn xml_path_for_yaml(yaml_path: &Path, source_root: &Path, output_root: &Path) -> PathBuf {
-    let relative = yaml_path.strip_prefix(source_root).unwrap_or(yaml_path);
+    let relative = safe_relative(yaml_path, source_root);
     let mut out = output_root.join(relative);
     let name = out
         .file_name()
@@ -277,8 +330,18 @@ fn xml_path_for_yaml(yaml_path: &Path, source_root: &Path, output_root: &Path) -
     out
 }
 
+fn validate_paths(paths: &[PathBuf]) -> Result<()> {
+    for p in paths {
+        if !p.exists() {
+            anyhow::bail!("Path not found: {}", p.display());
+        }
+    }
+    Ok(())
+}
+
 /// Pack: XML → YAML
 pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
+    validate_paths(&opts.paths)?;
     let files = find_sf_xml_files_from_opts(opts);
     let root = common_root(opts);
     let mut stats = ConvertStats::new();
@@ -309,6 +372,7 @@ pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
 
 /// Unpack: YAML → XML
 pub fn unpack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
+    validate_paths(&opts.paths)?;
     let files = find_yaml_files_from_opts(opts);
     let root = common_root(opts);
     let mut stats = ConvertStats::new();
@@ -338,6 +402,7 @@ pub fn unpack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
 
 /// Stats: preview without writing, with real token counting.
 pub fn stats(opts: &ConvertOpts) -> Result<ConvertStats> {
+    validate_paths(&opts.paths)?;
     let files = find_sf_xml_files_from_opts(opts);
     let root = common_root(opts);
     let mut stats = ConvertStats::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(name = "sf-compact")]
 #[command(
-    about = "Convert Salesforce metadata XML to AI-friendly YAML and back. Lossless roundtrip."
+    about = "Convert Salesforce metadata XML to AI-friendly YAML and back. Semantically lossless roundtrip."
 )]
 #[command(version)]
 struct Cli {
@@ -36,7 +36,7 @@ enum Commands {
         #[arg(long)]
         include: Option<String>,
     },
-    /// Convert compact YAML back to Salesforce XML metadata (lossless)
+    /// Convert compact YAML back to Salesforce XML metadata (semantically lossless)
     Unpack {
         /// Source path: directory or specific file(s)
         #[arg(default_value = ".sf-compact")]
@@ -102,13 +102,13 @@ fn main() -> Result<()> {
             };
             let stats = convert::pack(&opts, &output)?;
             println!(
-                "Packed {} files: {} → {} bytes ({:.1}% reduction, ~{} tokens saved)",
+                "Packed {} files: {} → {} bytes ({:.1}% reduction)",
                 stats.files_processed,
                 stats.original_bytes,
                 stats.compact_bytes,
                 stats.reduction_percent(),
-                stats.tokens_saved(),
             );
+            println!("Run `sf-compact stats` for detailed token savings.");
         }
         Commands::Unpack {
             source,

--- a/src/yaml_writer.rs
+++ b/src/yaml_writer.rs
@@ -215,21 +215,14 @@ fn simple_node_to_value(node: &XmlNode) -> Value {
     Value::Mapping(map)
 }
 
-/// Parse text into appropriate YAML type (bool, int, float, or string).
+/// Parse text into appropriate YAML type.
+/// Only converts "true"/"false" to bools. All other values stay as strings
+/// to preserve formatting (leading zeros, decimal notation, etc.).
 fn parse_smart_value(text: &str) -> Value {
     match text {
         "true" => Value::Bool(true),
         "false" => Value::Bool(false),
-        "" => Value::String(String::new()),
-        _ => {
-            if let Ok(n) = text.parse::<i64>() {
-                Value::Number(serde_yaml::Number::from(n))
-            } else if let Ok(f) = text.parse::<f64>() {
-                Value::Number(serde_yaml::Number::from(f))
-            } else {
-                Value::String(text.to_string())
-            }
-        }
+        _ => Value::String(text.to_string()),
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -184,3 +184,163 @@ fn empty_directory_produces_zero_stats() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("0 files"), "should report 0 files");
 }
+
+#[test]
+fn nonexistent_path_fails() {
+    let output = sf_compact()
+        .args(["pack", "/nonexistent/path/that/does/not/exist"])
+        .output()
+        .expect("failed to run");
+    assert!(!output.status.success(), "should fail on nonexistent path");
+}
+
+#[test]
+fn numeric_strings_preserved_in_roundtrip() {
+    // Create a minimal XML with numeric-like strings (leading zeros, decimals)
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>0012</status>
+</ApexClass>"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let xml_path = dir.path().join("Test.cls-meta.xml");
+    std::fs::write(&xml_path, xml).unwrap();
+
+    let packed = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Pack
+    let output = sf_compact()
+        .args([
+            "pack",
+            xml_path.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pack");
+    assert!(output.status.success(), "pack failed");
+
+    // Unpack
+    let output = sf_compact()
+        .args([
+            "unpack",
+            packed.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to unpack");
+    assert!(output.status.success(), "unpack failed");
+
+    // Find the restored XML and check values
+    let restored = unpacked.path().join("Test.cls-meta.xml");
+    assert!(restored.exists(), "restored file not found");
+    let content = std::fs::read_to_string(&restored).unwrap();
+    assert!(
+        content.contains(">59.0<"),
+        "apiVersion 59.0 was corrupted: {content}"
+    );
+    assert!(
+        content.contains(">0012<"),
+        "leading-zero string 0012 was corrupted: {content}"
+    );
+}
+
+#[test]
+fn unpack_ignores_non_sf_compact_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create a random YAML file that is NOT sf-compact format
+    std::fs::write(dir.path().join("random.yaml"), "key: value\n").unwrap();
+    // Also create a proper sf-compact YAML
+    std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+    std::fs::write(
+        dir.path().join("sub/Test.cls-meta.yaml"),
+        "_tag: ApexClass\n_ns: http://soap.sforce.com/2006/04/metadata\napiVersion: '59.0'\nstatus: Active\n",
+    )
+    .unwrap();
+
+    let unpacked = tempfile::tempdir().unwrap();
+
+    let output = sf_compact()
+        .args([
+            "unpack",
+            dir.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run unpack");
+    assert!(
+        output.status.success(),
+        "unpack should not crash on dir with mixed YAML: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unpacked 1 files"),
+        "should only unpack sf-compact YAML, got: {stdout}"
+    );
+}
+
+#[test]
+fn pack_does_not_show_token_count() {
+    let packed = tempfile::tempdir().unwrap();
+
+    let output = sf_compact()
+        .args([
+            "pack",
+            "tests/fixtures",
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run pack");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("tokens saved"),
+        "pack should not print token count: {stdout}"
+    );
+}
+
+#[test]
+fn pack_with_absolute_paths() {
+    let fixtures = std::fs::canonicalize("tests/fixtures").unwrap();
+    let packed = tempfile::tempdir().unwrap();
+
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run pack with absolute path");
+    assert!(
+        output.status.success(),
+        "pack with absolute path failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify files ended up inside the output directory, not alongside sources
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packed 5 files"),
+        "unexpected output: {stdout}"
+    );
+
+    // Check that YAML files are inside packed dir
+    let yaml_profile = packed
+        .path()
+        .join("force-app/main/default/profiles/Admin.profile-meta.yaml");
+    assert!(
+        yaml_profile.exists(),
+        "YAML should be inside output dir, not alongside source"
+    );
+}


### PR DESCRIPTION
## Summary
- **P1**: Stop numeric coercion that corrupted values like `0012` → `12` during roundtrip
- **P1**: Fix multi-source absolute path handling (files now correctly land in output dir)
- **P1**: Update "lossless" → "semantically lossless" (element order may change, which is OK for Salesforce metadata)
- **P2**: Replace naive glob with proper `glob` crate for `--include` patterns
- **P2**: Remove misleading token count from `pack` output (use `stats` for token info)
- **P2**: Restrict `unpack` to `-meta.yaml` files only (prevents crash on non-sf-compact YAML)
- **P3**: Fail on nonexistent paths instead of silently reporting 0 files
- **P3**: Fix metadata type count in README (46 extensions → 41 unique types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)