### PR TITLE
Add config file system for per-type format control (#2)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,185 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const CONFIG_FILENAME: &str = ".sfcompact.yaml";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SfCompactConfig {
+    #[serde(default = "default_format")]
+    pub default_format: String,
+
+    #[serde(default)]
+    pub formats: BTreeMap<String, String>,
+
+    #[serde(default)]
+    pub skip: Vec<String>,
+}
+
+fn default_format() -> String {
+    "yaml".to_string()
+}
+
+impl Default for SfCompactConfig {
+    fn default() -> Self {
+        Self {
+            default_format: default_format(),
+            formats: BTreeMap::new(),
+            skip: Vec::new(),
+        }
+    }
+}
+
+impl SfCompactConfig {
+    /// Create a config with smart defaults based on manifest metadata.
+    /// Order-sensitive types get `json`, everything else gets `yaml`.
+    pub fn with_smart_defaults(
+        entries: &[(String, bool, Vec<String>)], // (type_name, order_sensitive, supported_formats)
+    ) -> Self {
+        let mut formats = BTreeMap::new();
+        for (type_name, order_sensitive, _supported) in entries {
+            if *order_sensitive {
+                formats.insert(type_name.clone(), "json".to_string());
+            }
+        }
+        Self {
+            default_format: default_format(),
+            formats,
+            skip: Vec::new(),
+        }
+    }
+
+    /// Return the format configured for a given metadata type name.
+    /// Falls back to default_format if no type-specific override exists.
+    pub fn format_for_type(&self, type_name: &str) -> &str {
+        self.formats
+            .get(type_name)
+            .map(|s| s.as_str())
+            .unwrap_or(&self.default_format)
+    }
+
+    /// Check if a metadata type should be skipped.
+    pub fn should_skip(&self, type_name: &str) -> bool {
+        self.skip.iter().any(|s| s == type_name)
+    }
+}
+
+/// Find `.sfcompact.yaml` starting from `start_dir` and walking up to parent directories.
+pub fn find_config_file(start_dir: &Path) -> Option<PathBuf> {
+    let mut dir = start_dir.to_path_buf();
+    loop {
+        let candidate = dir.join(CONFIG_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// Load config from the given directory (or parent dirs). Returns default if not found.
+pub fn load_config(start_dir: &Path) -> Result<SfCompactConfig> {
+    match find_config_file(start_dir) {
+        Some(path) => {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+            let config: SfCompactConfig = serde_yaml::from_str(&content)
+                .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
+            Ok(config)
+        }
+        None => Ok(SfCompactConfig::default()),
+    }
+}
+
+/// Load config from a specific file path.
+pub fn load_config_from(path: &Path) -> Result<SfCompactConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+    let config: SfCompactConfig = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
+    Ok(config)
+}
+
+/// Save config to a specific file path.
+pub fn save_config(config: &SfCompactConfig, path: &Path) -> Result<()> {
+    let yaml = serde_yaml::to_string(config).context("Failed to serialize config to YAML")?;
+    std::fs::write(path, &yaml)
+        .with_context(|| format!("Failed to write config file: {}", path.display()))?;
+    Ok(())
+}
+
+/// Save config to `.sfcompact.yaml` in the given directory.
+pub fn save_config_to_dir(config: &SfCompactConfig, dir: &Path) -> Result<PathBuf> {
+    let path = dir.join(CONFIG_FILENAME);
+    save_config(config, &path)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = SfCompactConfig::default();
+        assert_eq!(config.default_format, "yaml");
+        assert!(config.formats.is_empty());
+        assert!(config.skip.is_empty());
+    }
+
+    #[test]
+    fn format_for_type_uses_override() {
+        let mut config = SfCompactConfig::default();
+        config
+            .formats
+            .insert("flow".to_string(), "json".to_string());
+        assert_eq!(config.format_for_type("flow"), "json");
+        assert_eq!(config.format_for_type("profile"), "yaml");
+    }
+
+    #[test]
+    fn should_skip() {
+        let mut config = SfCompactConfig::default();
+        config.skip.push("customMetadata".to_string());
+        assert!(config.should_skip("customMetadata"));
+        assert!(!config.should_skip("profile"));
+    }
+
+    #[test]
+    fn roundtrip_yaml() {
+        let mut config = SfCompactConfig::default();
+        config.default_format = "yaml".to_string();
+        config
+            .formats
+            .insert("flow".to_string(), "json".to_string());
+        config
+            .formats
+            .insert("flexipage".to_string(), "json".to_string());
+        config.skip.push("customMetadata".to_string());
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: SfCompactConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(config, parsed);
+    }
+
+    #[test]
+    fn smart_defaults_assigns_json_to_order_sensitive() {
+        let entries = vec![
+            (
+                "Flow".to_string(),
+                true,
+                vec!["yaml".to_string(), "json".to_string()],
+            ),
+            (
+                "Profile".to_string(),
+                false,
+                vec!["yaml".to_string(), "json".to_string()],
+            ),
+        ];
+        let config = SfCompactConfig::with_smart_defaults(&entries);
+        assert_eq!(config.format_for_type("Flow"), "json");
+        assert_eq!(config.format_for_type("Profile"), "yaml");
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::xml_parser;
 use crate::yaml_writer;
 use anyhow::{Context, Result};
@@ -147,15 +148,37 @@ fn is_sf_metadata(path: &Path) -> bool {
 }
 
 fn metadata_type(path: &Path) -> String {
+    metadata_type_for_ext(path, "-meta.xml")
+}
+
+fn metadata_type_for_ext(path: &Path, suffix: &str) -> String {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    // Extract the type from e.g. "Admin.profile-meta.xml" → "profile"
-    if let Some(pos) = name.rfind("-meta.xml") {
+    if let Some(pos) = name.rfind(suffix) {
         let before = &name[..pos];
         if let Some(dot) = before.rfind('.') {
             return before[dot + 1..].to_string();
         }
     }
     "unknown".to_string()
+}
+
+/// Map a short metadata_type (like "flow") to the manifest type name (like "Flow").
+/// Used for config lookup.
+fn manifest_type_name(short_type: &str) -> String {
+    // We look up from the classify function in manifest via the extension mapping
+    let ext = format!("{short_type}-meta.xml");
+    for sf_ext in SF_META_EXTENSIONS {
+        if *sf_ext == ext {
+            // Found the extension, now get the type name from manifest
+            return crate::manifest::build_manifest()
+                .supported_metadata
+                .into_iter()
+                .find(|e| e.extension == ext)
+                .map(|e| e.meta_type)
+                .unwrap_or_else(|| short_type.to_string());
+        }
+    }
+    short_type.to_string()
 }
 
 fn find_sf_xml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
@@ -346,7 +369,29 @@ pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
     let root = common_root(opts);
     let mut stats = ConvertStats::new();
 
+    // Load config from current directory (or parent dirs)
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cfg = config::load_config(&cwd).unwrap_or_default();
+
     for xml_path in &files {
+        // Check if this type should be skipped
+        let short_type = metadata_type(xml_path);
+        let type_name = manifest_type_name(&short_type);
+        if cfg.should_skip(&type_name) || cfg.should_skip(&short_type) {
+            continue;
+        }
+
+        // Check the configured format for this type
+        let format = cfg.format_for_type(&type_name);
+        let format_alt = cfg.format_for_type(&short_type);
+        let effective_format = if format != "yaml" { format } else { format_alt };
+        if effective_format != "yaml" {
+            eprintln!(
+                "Warning: {} format not yet supported for {}, using YAML",
+                effective_format, type_name
+            );
+        }
+
         let xml_content = fs::read_to_string(xml_path)
             .with_context(|| format!("Reading {}", xml_path.display()))?;
         let xml_bytes = xml_content.len() as u64;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod convert;
 mod manifest;
 mod mcp;
@@ -73,6 +74,11 @@ enum Commands {
         #[command(subcommand)]
         mode: InitMode,
     },
+    /// Manage .sfcompact.yaml configuration
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -85,6 +91,26 @@ enum InitMode {
         #[arg(long, default_value = "SF_COMPACT.md")]
         name: String,
     },
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Create .sfcompact.yaml with smart defaults
+    Init,
+    /// Set format for metadata types (e.g. `config set flow json profile yaml`) or set default format (`config set default json`)
+    Set {
+        /// Key-value pairs: type1 format1 type2 format2 ... or "default" format
+        #[arg(required = true, num_args = 2..)]
+        pairs: Vec<String>,
+    },
+    /// Add a metadata type to the skip list
+    Skip {
+        /// Metadata type name to skip
+        #[arg(required = true)]
+        type_name: String,
+    },
+    /// Display current configuration
+    Show,
 }
 
 fn main() -> Result<()> {
@@ -211,8 +237,90 @@ fn main() -> Result<()> {
                 init_instructions(&name)?;
             }
         },
+        Commands::Config { action } => match action {
+            ConfigAction::Init => {
+                config_init()?;
+            }
+            ConfigAction::Set { pairs } => {
+                config_set(&pairs)?;
+            }
+            ConfigAction::Skip { type_name } => {
+                config_skip(&type_name)?;
+            }
+            ConfigAction::Show => {
+                config_show()?;
+            }
+        },
     }
 
+    Ok(())
+}
+
+fn config_init() -> Result<()> {
+    let entries = manifest::metadata_info_for_config();
+    let cfg = config::SfCompactConfig::with_smart_defaults(&entries);
+    let path = config::save_config_to_dir(&cfg, &std::env::current_dir()?)?;
+    println!("Created {}", path.display());
+    Ok(())
+}
+
+fn config_set(pairs: &[String]) -> Result<()> {
+    if !pairs.len().is_multiple_of(2) {
+        anyhow::bail!(
+            "Expected key-value pairs (even number of arguments), got {}",
+            pairs.len()
+        );
+    }
+
+    let cwd = std::env::current_dir()?;
+    let config_path = config::find_config_file(&cwd).unwrap_or_else(|| cwd.join(".sfcompact.yaml"));
+
+    let mut cfg = if config_path.exists() {
+        config::load_config_from(&config_path)?
+    } else {
+        config::SfCompactConfig::default()
+    };
+
+    for chunk in pairs.chunks(2) {
+        let key = &chunk[0];
+        let value = &chunk[1];
+
+        if key == "default" {
+            cfg.default_format = value.clone();
+        } else {
+            cfg.formats.insert(key.clone(), value.clone());
+        }
+    }
+
+    config::save_config(&cfg, &config_path)?;
+    println!("Updated {}", config_path.display());
+    Ok(())
+}
+
+fn config_skip(type_name: &str) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let config_path = config::find_config_file(&cwd).unwrap_or_else(|| cwd.join(".sfcompact.yaml"));
+
+    let mut cfg = if config_path.exists() {
+        config::load_config_from(&config_path)?
+    } else {
+        config::SfCompactConfig::default()
+    };
+
+    if !cfg.skip.contains(&type_name.to_string()) {
+        cfg.skip.push(type_name.to_string());
+    }
+
+    config::save_config(&cfg, &config_path)?;
+    println!("Updated {}", config_path.display());
+    Ok(())
+}
+
+fn config_show() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let cfg = config::load_config(&cwd)?;
+    let yaml = serde_yaml::to_string(&cfg).context("Failed to serialize config")?;
+    print!("{yaml}");
     Ok(())
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,62 +8,64 @@ pub struct Manifest {
     pub supported_metadata: Vec<MetadataEntry>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct MetadataEntry {
     pub extension: String,
     #[serde(rename = "type")]
     pub meta_type: String,
     pub category: String,
+    pub order_sensitive: bool,
+    pub supported_formats: Vec<String>,
 }
 
-/// Map an extension to a human-readable type name and category.
-fn classify(ext: &str) -> (&str, &str) {
+/// Map an extension to (type_name, category, order_sensitive).
+fn classify(ext: &str) -> (&str, &str, bool) {
     match ext {
-        "profile-meta.xml" => ("Profile", "security"),
-        "permissionset-meta.xml" => ("PermissionSet", "security"),
-        "permissionsetgroup-meta.xml" => ("PermissionSetGroup", "security"),
-        "object-meta.xml" => ("CustomObject", "schema"),
-        "field-meta.xml" => ("CustomField", "schema"),
-        "validationRule-meta.xml" => ("ValidationRule", "schema"),
-        "flow-meta.xml" => ("Flow", "automation"),
-        "layout-meta.xml" => ("Layout", "ui"),
-        "labels-meta.xml" => ("CustomLabels", "ui"),
-        "cls-meta.xml" => ("ApexClass", "code"),
-        "trigger-meta.xml" => ("ApexTrigger", "code"),
-        "component-meta.xml" => ("ApexComponent", "code"),
-        "page-meta.xml" => ("ApexPage", "code"),
-        "js-meta.xml" => ("LightningComponentBundle", "code"),
-        "css-meta.xml" => ("LightningComponentBundle", "code"),
-        "html-meta.xml" => ("LightningComponentBundle", "code"),
-        "xml-meta.xml" => ("LightningComponentBundle", "code"),
-        "email-meta.xml" => ("EmailTemplate", "content"),
-        "workflow-meta.xml" => ("Workflow", "automation"),
-        "app-meta.xml" => ("CustomApplication", "ui"),
-        "tab-meta.xml" => ("CustomTab", "ui"),
-        "flexipage-meta.xml" => ("FlexiPage", "ui"),
-        "site-meta.xml" => ("CustomSite", "ui"),
-        "remoteSite-meta.xml" => ("RemoteSiteSetting", "security"),
-        "cspTrustedSite-meta.xml" => ("CspTrustedSite", "security"),
-        "connectedApp-meta.xml" => ("ConnectedApp", "security"),
-        "customMetadata-meta.xml" => ("CustomMetadata", "schema"),
-        "globalValueSet-meta.xml" => ("GlobalValueSet", "schema"),
-        "standardValueSet-meta.xml" => ("StandardValueSet", "schema"),
-        "quickAction-meta.xml" => ("QuickAction", "ui"),
-        "reportType-meta.xml" => ("ReportType", "analytics"),
-        "report-meta.xml" => ("Report", "analytics"),
-        "dashboard-meta.xml" => ("Dashboard", "analytics"),
-        "pathAssistant-meta.xml" => ("PathAssistant", "ui"),
-        "listView-meta.xml" => ("ListView", "ui"),
-        "recordType-meta.xml" => ("RecordType", "schema"),
-        "compactLayout-meta.xml" => ("CompactLayout", "ui"),
-        "webLink-meta.xml" => ("WebLink", "ui"),
-        "sharingRules-meta.xml" => ("SharingRules", "security"),
-        "assignmentRules-meta.xml" => ("AssignmentRules", "automation"),
-        "autoResponseRules-meta.xml" => ("AutoResponseRules", "automation"),
-        "escalationRules-meta.xml" => ("EscalationRules", "automation"),
-        "matchingRule-meta.xml" => ("MatchingRule", "schema"),
-        "duplicateRule-meta.xml" => ("DuplicateRule", "schema"),
-        _ => ("Unknown", "other"),
+        "profile-meta.xml" => ("Profile", "security", false),
+        "permissionset-meta.xml" => ("PermissionSet", "security", false),
+        "permissionsetgroup-meta.xml" => ("PermissionSetGroup", "security", false),
+        "object-meta.xml" => ("CustomObject", "schema", false),
+        "field-meta.xml" => ("CustomField", "schema", false),
+        "validationRule-meta.xml" => ("ValidationRule", "schema", false),
+        "flow-meta.xml" => ("Flow", "automation", true),
+        "layout-meta.xml" => ("Layout", "ui", true),
+        "labels-meta.xml" => ("CustomLabels", "ui", false),
+        "cls-meta.xml" => ("ApexClass", "code", false),
+        "trigger-meta.xml" => ("ApexTrigger", "code", false),
+        "component-meta.xml" => ("ApexComponent", "code", false),
+        "page-meta.xml" => ("ApexPage", "code", false),
+        "js-meta.xml" => ("LightningComponentBundle", "code", false),
+        "css-meta.xml" => ("LightningComponentBundle", "code", false),
+        "html-meta.xml" => ("LightningComponentBundle", "code", false),
+        "xml-meta.xml" => ("LightningComponentBundle", "code", false),
+        "email-meta.xml" => ("EmailTemplate", "content", false),
+        "workflow-meta.xml" => ("Workflow", "automation", false),
+        "app-meta.xml" => ("CustomApplication", "ui", false),
+        "tab-meta.xml" => ("CustomTab", "ui", false),
+        "flexipage-meta.xml" => ("FlexiPage", "ui", true),
+        "site-meta.xml" => ("CustomSite", "ui", false),
+        "remoteSite-meta.xml" => ("RemoteSiteSetting", "security", false),
+        "cspTrustedSite-meta.xml" => ("CspTrustedSite", "security", false),
+        "connectedApp-meta.xml" => ("ConnectedApp", "security", false),
+        "customMetadata-meta.xml" => ("CustomMetadata", "schema", false),
+        "globalValueSet-meta.xml" => ("GlobalValueSet", "schema", false),
+        "standardValueSet-meta.xml" => ("StandardValueSet", "schema", false),
+        "quickAction-meta.xml" => ("QuickAction", "ui", false),
+        "reportType-meta.xml" => ("ReportType", "analytics", false),
+        "report-meta.xml" => ("Report", "analytics", false),
+        "dashboard-meta.xml" => ("Dashboard", "analytics", false),
+        "pathAssistant-meta.xml" => ("PathAssistant", "ui", false),
+        "listView-meta.xml" => ("ListView", "ui", false),
+        "recordType-meta.xml" => ("RecordType", "schema", false),
+        "compactLayout-meta.xml" => ("CompactLayout", "ui", false),
+        "webLink-meta.xml" => ("WebLink", "ui", false),
+        "sharingRules-meta.xml" => ("SharingRules", "security", false),
+        "assignmentRules-meta.xml" => ("AssignmentRules", "automation", false),
+        "autoResponseRules-meta.xml" => ("AutoResponseRules", "automation", false),
+        "escalationRules-meta.xml" => ("EscalationRules", "automation", false),
+        "matchingRule-meta.xml" => ("MatchingRule", "schema", false),
+        "duplicateRule-meta.xml" => ("DuplicateRule", "schema", false),
+        _ => ("Unknown", "other", false),
     }
 }
 
@@ -71,11 +73,13 @@ pub fn build_manifest() -> Manifest {
     let entries = SF_META_EXTENSIONS
         .iter()
         .map(|ext| {
-            let (meta_type, category) = classify(ext);
+            let (meta_type, category, order_sensitive) = classify(ext);
             MetadataEntry {
                 extension: ext.to_string(),
                 meta_type: meta_type.to_string(),
                 category: category.to_string(),
+                order_sensitive,
+                supported_formats: vec!["yaml".to_string(), "json".to_string()],
             }
         })
         .collect();
@@ -84,4 +88,22 @@ pub fn build_manifest() -> Manifest {
         version: env!("CARGO_PKG_VERSION").to_string(),
         supported_metadata: entries,
     }
+}
+
+/// Return a list of (type_name, order_sensitive, supported_formats) for config init.
+pub fn metadata_info_for_config() -> Vec<(String, bool, Vec<String>)> {
+    let manifest = build_manifest();
+    let mut seen = std::collections::HashSet::new();
+    let mut result = Vec::new();
+    for entry in manifest.supported_metadata {
+        // Deduplicate by type name (e.g. LightningComponentBundle appears multiple times)
+        if seen.insert(entry.meta_type.clone()) {
+            result.push((
+                entry.meta_type,
+                entry.order_sensitive,
+                entry.supported_formats,
+            ));
+        }
+    }
+    result
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -344,3 +344,288 @@ fn pack_with_absolute_paths() {
         "YAML should be inside output dir, not alongside source"
     );
 }
+
+// ─── Config tests ───────────────────────────────────────────────
+
+#[test]
+fn config_init_creates_file() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config init");
+    assert!(
+        output.status.success(),
+        "config init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config_path = dir.path().join(".sfcompact.yaml");
+    assert!(config_path.exists(), ".sfcompact.yaml should be created");
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    // Should have smart defaults: order-sensitive types set to json
+    assert!(
+        content.contains("default_format"),
+        "config should contain default_format"
+    );
+    // Flow is order-sensitive, should be json
+    assert!(
+        content.contains("Flow: json") || content.contains("Flow: json"),
+        "Flow should be set to json in smart defaults, got: {content}"
+    );
+}
+
+#[test]
+fn config_set_single_type() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // First init config
+    let output = sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config init");
+    assert!(output.status.success());
+
+    // Set a single type
+    let output = sf_compact()
+        .args(["config", "set", "flow", "json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config set");
+    assert!(
+        output.status.success(),
+        "config set failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(dir.path().join(".sfcompact.yaml")).unwrap();
+    assert!(
+        content.contains("flow: json"),
+        "config should contain flow: json, got: {content}"
+    );
+}
+
+#[test]
+fn config_set_batch() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Init config first
+    sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Set multiple types in one call
+    let output = sf_compact()
+        .args(["config", "set", "flow", "json", "profile", "yaml"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config set batch");
+    assert!(
+        output.status.success(),
+        "config set batch failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(dir.path().join(".sfcompact.yaml")).unwrap();
+    assert!(
+        content.contains("flow: json"),
+        "config should contain flow: json, got: {content}"
+    );
+    assert!(
+        content.contains("profile: yaml"),
+        "config should contain profile: yaml, got: {content}"
+    );
+}
+
+#[test]
+fn config_set_default() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Init config first
+    sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Change the default format
+    let output = sf_compact()
+        .args(["config", "set", "default", "json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config set default");
+    assert!(
+        output.status.success(),
+        "config set default failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(dir.path().join(".sfcompact.yaml")).unwrap();
+    assert!(
+        content.contains("default_format: json"),
+        "config should have default_format: json, got: {content}"
+    );
+}
+
+#[test]
+fn config_skip_type() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Init config first
+    sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Add to skip list
+    let output = sf_compact()
+        .args(["config", "skip", "customMetadata"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config skip");
+    assert!(
+        output.status.success(),
+        "config skip failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(dir.path().join(".sfcompact.yaml")).unwrap();
+    assert!(
+        content.contains("customMetadata"),
+        "config should contain customMetadata in skip list, got: {content}"
+    );
+}
+
+#[test]
+fn config_show_displays_config() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Init config first
+    sf_compact()
+        .args(["config", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let output = sf_compact()
+        .args(["config", "show"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run config show");
+    assert!(
+        output.status.success(),
+        "config show failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("default_format"),
+        "config show should display default_format, got: {stdout}"
+    );
+}
+
+#[test]
+fn pack_respects_skip_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let packed = tempfile::tempdir().unwrap();
+
+    // Create a config that skips "flow" type
+    let config_content = "default_format: yaml\nformats: {}\nskip:\n- flow\n";
+    std::fs::write(dir.path().join(".sfcompact.yaml"), config_content).unwrap();
+
+    // Copy test fixtures into the temp dir
+    let fixtures = std::path::Path::new("tests/fixtures");
+    copy_dir_recursive(fixtures, &dir.path().join("tests/fixtures"));
+
+    let output = sf_compact()
+        .args([
+            "pack",
+            dir.path().join("tests/fixtures").to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run pack with skip config");
+    assert!(
+        output.status.success(),
+        "pack failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Without skip, we pack 5 files. With flow skipped, we should pack 4.
+    assert!(
+        stdout.contains("Packed 4 files"),
+        "should pack 4 files (skipping flow), got: {stdout}"
+    );
+}
+
+#[test]
+fn manifest_includes_order_sensitive() {
+    let output = sf_compact()
+        .args(["manifest"])
+        .output()
+        .expect("failed to run manifest");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("manifest output is not valid JSON");
+
+    let metadata = parsed["supported_metadata"].as_array().unwrap();
+
+    // Check that Flow is order_sensitive: true
+    let flow_entry = metadata
+        .iter()
+        .find(|e| e["type"] == "Flow")
+        .expect("Flow entry not found in manifest");
+    assert_eq!(
+        flow_entry["order_sensitive"], true,
+        "Flow should be order_sensitive"
+    );
+
+    // Check that Profile is order_sensitive: false
+    let profile_entry = metadata
+        .iter()
+        .find(|e| e["type"] == "Profile")
+        .expect("Profile entry not found in manifest");
+    assert_eq!(
+        profile_entry["order_sensitive"], false,
+        "Profile should not be order_sensitive"
+    );
+
+    // Check that supported_formats is present
+    let formats = flow_entry["supported_formats"].as_array().unwrap();
+    assert!(
+        formats.contains(&serde_json::json!("yaml")),
+        "supported_formats should include yaml"
+    );
+    assert!(
+        formats.contains(&serde_json::json!("json")),
+        "supported_formats should include json"
+    );
+}
+
+/// Helper to recursively copy a directory.
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            std::fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `.sfcompact.yaml` config file for per-type format settings
- `sf-compact config init` creates config with smart defaults (json for order-sensitive types)
- `sf-compact config set` supports batch: `config set flow json profile yaml cls yaml`
- `sf-compact config skip` to exclude types from conversion
- `sf-compact config show` to display current config
- Manifest enhanced with `order_sensitive` and `supported_formats` per type
- `pack` reads config and skips configured types (JSON format falls back to YAML with warning until #3)
- 8 new integration tests (20 total)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)