### PR TITLE
Add cross-platform release workflow and crates.io metadata (#6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl-tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../sf-compact-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz sf-compact
+          cd ../../..
+
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/sf-compact.exe" -DestinationPath "sf-compact-${{ github.event.release.tag_name }}-${{ matrix.target }}.zip"
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            gh release upload "${{ github.event.release.tag_name }}" \
+              "sf-compact-${{ github.event.release.tag_name }}-${{ matrix.target }}.zip" \
+              --clobber
+          else
+            gh release upload "${{ github.event.release.tag_name }}" \
+              "sf-compact-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz" \
+              --clobber
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/vradko/sf-compact"
 homepage = "https://github.com/vradko/sf-compact"
 keywords = ["salesforce", "metadata", "yaml", "ai", "token-optimization"]
 categories = ["command-line-utilities", "development-tools"]
+readme = "README.md"
+exclude = ["tests/", ".github/", "target/"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml` for automated binary builds on GitHub Release
- Targets: macOS aarch64, macOS x86_64, Linux x86_64 (musl static), Windows x86_64
- Archives: `sf-compact-<tag>-<target>.tar.gz` (.zip for Windows)
- Cargo.toml: added `readme` and `exclude` for clean crates.io packaging
- Verified with `cargo package --list`

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)