### PR TITLE
Add JSON format, refactor metadata types into single source of truth (#3)

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,6 @@
 use crate::config;
+use crate::json_writer;
+use crate::metadata_types;
 use crate::xml_parser;
 use crate::yaml_writer;
 use anyhow::{Context, Result};
@@ -7,59 +9,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-pub const SF_META_EXTENSIONS: &[&str] = &[
-    "profile-meta.xml",
-    "permissionset-meta.xml",
-    "permissionsetgroup-meta.xml",
-    "object-meta.xml",
-    "field-meta.xml",
-    "validationRule-meta.xml",
-    "flow-meta.xml",
-    "layout-meta.xml",
-    "labels-meta.xml",
-    "cls-meta.xml",
-    "trigger-meta.xml",
-    "component-meta.xml",
-    "page-meta.xml",
-    "js-meta.xml",
-    "css-meta.xml",
-    "html-meta.xml",
-    "xml-meta.xml",
-    "email-meta.xml",
-    "workflow-meta.xml",
-    "app-meta.xml",
-    "tab-meta.xml",
-    "flexipage-meta.xml",
-    "site-meta.xml",
-    "remoteSite-meta.xml",
-    "cspTrustedSite-meta.xml",
-    "connectedApp-meta.xml",
-    "customMetadata-meta.xml",
-    "globalValueSet-meta.xml",
-    "standardValueSet-meta.xml",
-    "quickAction-meta.xml",
-    "reportType-meta.xml",
-    "report-meta.xml",
-    "dashboard-meta.xml",
-    "pathAssistant-meta.xml",
-    "listView-meta.xml",
-    "recordType-meta.xml",
-    "compactLayout-meta.xml",
-    "webLink-meta.xml",
-    "sharingRules-meta.xml",
-    "assignmentRules-meta.xml",
-    "autoResponseRules-meta.xml",
-    "escalationRules-meta.xml",
-    "matchingRule-meta.xml",
-    "duplicateRule-meta.xml",
-];
-
 /// Options for selecting which files to process.
 pub struct ConvertOpts {
     /// One or more paths (files or directories).
     pub paths: Vec<PathBuf>,
     /// Optional glob filter (e.g. "profiles/**", "*.flow-meta.xml").
     pub include: Option<String>,
+    /// CLI format override (takes precedence over config).
+    pub format_override: Option<String>,
 }
 
 pub struct FileStats {
@@ -144,7 +101,7 @@ fn count_tokens(text: &str) -> usize {
 
 fn is_sf_metadata(path: &Path) -> bool {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    SF_META_EXTENSIONS.iter().any(|ext| name.ends_with(ext))
+    metadata_types::is_sf_metadata_filename(name)
 }
 
 fn metadata_type(path: &Path) -> String {
@@ -163,22 +120,8 @@ fn metadata_type_for_ext(path: &Path, suffix: &str) -> String {
 }
 
 /// Map a short metadata_type (like "flow") to the manifest type name (like "Flow").
-/// Used for config lookup.
 fn manifest_type_name(short_type: &str) -> String {
-    // We look up from the classify function in manifest via the extension mapping
-    let ext = format!("{short_type}-meta.xml");
-    for sf_ext in SF_META_EXTENSIONS {
-        if *sf_ext == ext {
-            // Found the extension, now get the type name from manifest
-            return crate::manifest::build_manifest()
-                .supported_metadata
-                .into_iter()
-                .find(|e| e.extension == ext)
-                .map(|e| e.meta_type)
-                .unwrap_or_else(|| short_type.to_string());
-        }
-    }
-    short_type.to_string()
+    metadata_types::manifest_type_for_short(short_type)
 }
 
 fn find_sf_xml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
@@ -209,22 +152,22 @@ fn find_sf_xml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
     files
 }
 
-fn is_sf_compact_yaml(path: &Path) -> bool {
+fn is_sf_compact_file(path: &Path) -> bool {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    name.ends_with("-meta.yaml")
+    name.ends_with("-meta.yaml") || name.ends_with("-meta.json")
 }
 
-fn find_yaml_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
+fn find_compact_files_from_opts(opts: &ConvertOpts) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
     for path in &opts.paths {
         if path.is_file() {
-            if is_sf_compact_yaml(path) {
+            if is_sf_compact_file(path) {
                 files.push(path.clone());
             }
         } else if path.is_dir() {
             for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
-                if entry.file_type().is_file() && is_sf_compact_yaml(entry.path()) {
+                if entry.file_type().is_file() && is_sf_compact_file(entry.path()) {
                     files.push(entry.path().to_path_buf());
                 }
             }
@@ -329,26 +272,39 @@ fn safe_relative(path: &Path, root: &Path) -> PathBuf {
         })
 }
 
-fn yaml_path_for_xml(xml_path: &Path, source_root: &Path, output_root: &Path) -> PathBuf {
+/// Compute compact output path for an XML file, using the given format extension.
+fn compact_path_for_xml(
+    xml_path: &Path,
+    source_root: &Path,
+    output_root: &Path,
+    format: &str,
+) -> PathBuf {
     let relative = safe_relative(xml_path, source_root);
     let mut out = output_root.join(relative);
+    let ext = if format == "json" {
+        "-meta.json"
+    } else {
+        "-meta.yaml"
+    };
     let name = out
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("")
-        .replace("-meta.xml", "-meta.yaml");
+        .replace("-meta.xml", ext);
     out.set_file_name(name);
     out
 }
 
-fn xml_path_for_yaml(yaml_path: &Path, source_root: &Path, output_root: &Path) -> PathBuf {
-    let relative = safe_relative(yaml_path, source_root);
+/// Compute XML output path for a compact file (YAML or JSON).
+fn xml_path_for_compact(compact_path: &Path, source_root: &Path, output_root: &Path) -> PathBuf {
+    let relative = safe_relative(compact_path, source_root);
     let mut out = output_root.join(relative);
     let name = out
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("")
-        .replace("-meta.yaml", "-meta.xml");
+        .replace("-meta.yaml", "-meta.xml")
+        .replace("-meta.json", "-meta.xml");
     out.set_file_name(name);
     out
 }
@@ -362,7 +318,26 @@ fn validate_paths(paths: &[PathBuf]) -> Result<()> {
     Ok(())
 }
 
-/// Pack: XML → YAML
+/// Determine effective format for a file, considering CLI override and config.
+fn effective_format(
+    short_type: &str,
+    type_name: &str,
+    cfg: &config::SfCompactConfig,
+    cli_override: &Option<String>,
+) -> String {
+    if let Some(fmt) = cli_override {
+        return fmt.clone();
+    }
+    let format = cfg.format_for_type(type_name);
+    let format_alt = cfg.format_for_type(short_type);
+    if format != "yaml" {
+        format.to_string()
+    } else {
+        format_alt.to_string()
+    }
+}
+
+/// Pack: XML → compact format (YAML or JSON)
 pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
     validate_paths(&opts.paths)?;
     let files = find_sf_xml_files_from_opts(opts);
@@ -381,16 +356,7 @@ pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
             continue;
         }
 
-        // Check the configured format for this type
-        let format = cfg.format_for_type(&type_name);
-        let format_alt = cfg.format_for_type(&short_type);
-        let effective_format = if format != "yaml" { format } else { format_alt };
-        if effective_format != "yaml" {
-            eprintln!(
-                "Warning: {} format not yet supported for {}, using YAML",
-                effective_format, type_name
-            );
-        }
+        let format = effective_format(&short_type, &type_name, &cfg, &opts.format_override);
 
         let xml_content = fs::read_to_string(xml_path)
             .with_context(|| format!("Reading {}", xml_path.display()))?;
@@ -399,46 +365,63 @@ pub fn pack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
         let node = xml_parser::parse_xml(&xml_content)
             .with_context(|| format!("Parsing {}", xml_path.display()))?;
 
-        let yaml = yaml_writer::xml_to_yaml(&node)
-            .with_context(|| format!("Converting {}", xml_path.display()))?;
-        let yaml_bytes = yaml.len() as u64;
+        let (compact_content, ext) = if format == "json" {
+            let json = json_writer::xml_to_json(&node)
+                .with_context(|| format!("Converting {} to JSON", xml_path.display()))?;
+            (json, "json")
+        } else {
+            let yaml = yaml_writer::xml_to_yaml(&node)
+                .with_context(|| format!("Converting {} to YAML", xml_path.display()))?;
+            (yaml, "yaml")
+        };
+        let compact_bytes = compact_content.len() as u64;
 
-        let yaml_path = yaml_path_for_xml(xml_path, &root, output);
-        if let Some(parent) = yaml_path.parent() {
+        let out_path = compact_path_for_xml(xml_path, &root, output, ext);
+        if let Some(parent) = out_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(&yaml_path, &yaml)?;
+        fs::write(&out_path, &compact_content)?;
 
-        accumulate_stats(&mut stats, xml_path, &root, xml_bytes, yaml_bytes, 0, 0);
+        accumulate_stats(&mut stats, xml_path, &root, xml_bytes, compact_bytes, 0, 0);
     }
 
     Ok(stats)
 }
 
-/// Unpack: YAML → XML
+/// Unpack: compact format (YAML or JSON) → XML
 pub fn unpack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
     validate_paths(&opts.paths)?;
-    let files = find_yaml_files_from_opts(opts);
+    let files = find_compact_files_from_opts(opts);
     let root = common_root(opts);
     let mut stats = ConvertStats::new();
 
-    for yaml_path in &files {
-        let yaml_content = fs::read_to_string(yaml_path)
-            .with_context(|| format!("Reading {}", yaml_path.display()))?;
+    for compact_path in &files {
+        let content = fs::read_to_string(compact_path)
+            .with_context(|| format!("Reading {}", compact_path.display()))?;
 
-        let node = yaml_writer::yaml_to_xml_node(&yaml_content)
-            .with_context(|| format!("Converting {}", yaml_path.display()))?;
+        let is_json = compact_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with("-meta.json"));
+
+        let node = if is_json {
+            json_writer::json_to_xml_node(&content)
+                .with_context(|| format!("Parsing JSON {}", compact_path.display()))?
+        } else {
+            yaml_writer::yaml_to_xml_node(&content)
+                .with_context(|| format!("Parsing YAML {}", compact_path.display()))?
+        };
 
         let xml = xml_parser::to_xml(&node);
 
-        let xml_path = xml_path_for_yaml(yaml_path, &root, output);
+        let xml_path = xml_path_for_compact(compact_path, &root, output);
         if let Some(parent) = xml_path.parent() {
             fs::create_dir_all(parent)?;
         }
         fs::write(&xml_path, &xml)?;
 
         stats.files_processed += 1;
-        stats.compact_bytes += yaml_content.len() as u64;
+        stats.compact_bytes += content.len() as u64;
         stats.original_bytes += xml.len() as u64;
     }
 
@@ -485,6 +468,7 @@ pub fn stats_path(source: &Path) -> Result<ConvertStats> {
     stats(&ConvertOpts {
         paths: vec![source.to_path_buf()],
         include: None,
+        format_override: None,
     })
 }
 
@@ -494,6 +478,7 @@ pub fn pack_path(source: &Path, output: &Path) -> Result<ConvertStats> {
         &ConvertOpts {
             paths: vec![source.to_path_buf()],
             include: None,
+            format_override: None,
         },
         output,
     )
@@ -505,6 +490,7 @@ pub fn unpack_path(source: &Path, output: &Path) -> Result<ConvertStats> {
         &ConvertOpts {
             paths: vec![source.to_path_buf()],
             include: None,
+            format_override: None,
         },
         output,
     )

--- a/src/json_writer.rs
+++ b/src/json_writer.rs
@@ -1,0 +1,378 @@
+use crate::xml_parser::{XmlNode, XmlValue};
+use anyhow::Result;
+use indexmap::IndexMap;
+use serde_json::Value;
+
+/// Convert a parsed XML tree to compact single-line JSON.
+/// Uses an order-preserving array-based children approach: every child element
+/// is stored inside `_children` as `{"_tag":"...","key":"val",...}` objects,
+/// which guarantees document-order fidelity (crucial for order-sensitive types
+/// like Flow and FlexiPage).
+pub fn xml_to_json(node: &XmlNode) -> Result<String> {
+    let value = node_to_json_value(node);
+    let json = serde_json::to_string(&value)?;
+    Ok(json)
+}
+
+/// Parse compact JSON back into an XmlNode tree.
+pub fn json_to_xml_node(json: &str) -> Result<XmlNode> {
+    let value: Value = serde_json::from_str(json)?;
+    json_value_to_node(&value)
+}
+
+// ─── XML → JSON ───────────────────────────────────────────────
+
+fn node_to_json_value(node: &XmlNode) -> Value {
+    let mut map = serde_json::Map::new();
+
+    map.insert("_tag".to_string(), Value::String(node.tag.clone()));
+
+    if let Some(ns) = &node.namespace {
+        map.insert("_ns".to_string(), Value::String(ns.clone()));
+    }
+
+    if !node.attrs.is_empty() {
+        let mut attrs = serde_json::Map::new();
+        for (k, v) in &node.attrs {
+            attrs.insert(k.clone(), Value::String(v.clone()));
+        }
+        map.insert("_attrs".to_string(), Value::Object(attrs));
+    }
+
+    if node.children.is_empty() {
+        return Value::Object(map);
+    }
+
+    // Single text child
+    if node.children.len() == 1 {
+        if let XmlValue::Text(t) = &node.children[0] {
+            map.insert("_text".to_string(), smart_json_value(t));
+            return Value::Object(map);
+        }
+    }
+
+    // Multiple text children (rare)
+    let text_parts: Vec<&str> = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            XmlValue::Text(t) => Some(t.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    if !text_parts.is_empty() {
+        if text_parts.len() == 1 {
+            map.insert(
+                "_text".to_string(),
+                Value::String(text_parts[0].to_string()),
+            );
+        } else {
+            map.insert(
+                "_text".to_string(),
+                Value::Array(
+                    text_parts
+                        .iter()
+                        .map(|t| Value::String(t.to_string()))
+                        .collect(),
+                ),
+            );
+        }
+    }
+
+    // All element children go into _children array, preserving exact document order
+    let child_nodes: Vec<Value> = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            XmlValue::Node(n) => Some(child_node_to_json(n)),
+            _ => None,
+        })
+        .collect();
+
+    if !child_nodes.is_empty() {
+        map.insert("_children".to_string(), Value::Array(child_nodes));
+    }
+
+    Value::Object(map)
+}
+
+/// Convert a child node to a compact JSON object.
+/// For simple text-leaf children, produce `{"_tag":"name","_text":"value"}`.
+/// For kv-container children (all children are text-leaves with unique tags),
+/// produce `{"_tag":"name","field":"val",...}`.
+/// For complex children, recurse fully.
+fn child_node_to_json(node: &XmlNode) -> Value {
+    // Text leaf: <foo>bar</foo>
+    if is_text_leaf(node) {
+        let mut m = serde_json::Map::new();
+        m.insert("_tag".to_string(), Value::String(node.tag.clone()));
+        let text = leaf_text(node);
+        m.insert("_text".to_string(), smart_json_value(text));
+        return Value::Object(m);
+    }
+
+    // Simple kv container: all children are text-leaves with unique tags
+    if is_simple_kv_node(node) {
+        let mut m = serde_json::Map::new();
+        m.insert("_tag".to_string(), Value::String(node.tag.clone()));
+        for child in &node.children {
+            if let XmlValue::Node(n) = child {
+                m.insert(n.tag.clone(), smart_json_value(leaf_text(n)));
+            }
+        }
+        return Value::Object(m);
+    }
+
+    // Complex node: full recursion
+    node_to_json_value(node)
+}
+
+fn smart_json_value(text: &str) -> Value {
+    match text {
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        _ => Value::String(text.to_string()),
+    }
+}
+
+fn is_text_leaf(node: &XmlNode) -> bool {
+    node.attrs.is_empty()
+        && node.children.len() <= 1
+        && node.children.iter().all(|c| matches!(c, XmlValue::Text(_)))
+}
+
+fn leaf_text(node: &XmlNode) -> &str {
+    node.children
+        .first()
+        .and_then(|c| match c {
+            XmlValue::Text(t) => Some(t.as_str()),
+            _ => None,
+        })
+        .unwrap_or("")
+}
+
+fn is_simple_kv_node(node: &XmlNode) -> bool {
+    if !node.attrs.is_empty() || node.children.is_empty() {
+        return false;
+    }
+    let has_text_children = node.children.iter().any(|c| matches!(c, XmlValue::Text(_)));
+    if has_text_children {
+        return false;
+    }
+    let mut seen_tags = std::collections::HashSet::new();
+    for c in &node.children {
+        if let XmlValue::Node(n) = c {
+            if !seen_tags.insert(&n.tag) {
+                return false;
+            }
+        }
+    }
+    node.children.iter().all(|c| match c {
+        XmlValue::Node(n) => {
+            n.attrs.is_empty()
+                && n.children.len() <= 1
+                && n.children.iter().all(|cc| matches!(cc, XmlValue::Text(_)))
+        }
+        XmlValue::Text(_) => false,
+    })
+}
+
+// ─── JSON → XML ───────────────────────────────────────────────
+
+fn json_value_to_node(value: &Value) -> Result<XmlNode> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("Expected JSON object at root"))?;
+
+    let tag = obj
+        .get("_tag")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing _tag in JSON node"))?
+        .to_string();
+
+    let namespace = obj.get("_ns").and_then(|v| v.as_str()).map(String::from);
+
+    let mut attrs = IndexMap::new();
+    if let Some(Value::Object(a)) = obj.get("_attrs") {
+        for (k, v) in a {
+            if let Some(val) = v.as_str() {
+                attrs.insert(k.clone(), val.to_string());
+            }
+        }
+    }
+
+    let mut children = Vec::new();
+
+    // Handle _text
+    if let Some(text_val) = obj.get("_text") {
+        match text_val {
+            Value::String(s) => children.push(XmlValue::Text(s.clone())),
+            Value::Bool(b) => children.push(XmlValue::Text(b.to_string())),
+            Value::Number(n) => children.push(XmlValue::Text(n.to_string())),
+            Value::Array(arr) => {
+                for item in arr {
+                    children.push(XmlValue::Text(json_value_to_string(item)));
+                }
+            }
+            Value::Null => {}
+            _ => children.push(XmlValue::Text(json_value_to_string(text_val))),
+        }
+    }
+
+    // Handle _children array (order-preserving)
+    if let Some(Value::Array(arr)) = obj.get("_children") {
+        for item in arr {
+            let child = reconstruct_child_from_json(item)?;
+            children.push(XmlValue::Node(child));
+        }
+    }
+
+    // Also handle non-reserved keys (for backward compat / alternative format)
+    let reserved = ["_tag", "_ns", "_attrs", "_text", "_children"];
+    for (key, val) in obj {
+        if reserved.contains(&key.as_str()) {
+            continue;
+        }
+        match val {
+            Value::Object(_) => {
+                let child = reconstruct_named_child_from_json(key, val)?;
+                children.push(XmlValue::Node(child));
+            }
+            Value::Array(arr) => {
+                for item in arr {
+                    let child = reconstruct_named_child_from_json(key, item)?;
+                    children.push(XmlValue::Node(child));
+                }
+            }
+            _ => {
+                let child = XmlNode {
+                    tag: key.clone(),
+                    namespace: None,
+                    attrs: IndexMap::new(),
+                    children: vec![XmlValue::Text(json_value_to_string(val))],
+                };
+                children.push(XmlValue::Node(child));
+            }
+        }
+    }
+
+    Ok(XmlNode {
+        tag,
+        namespace,
+        attrs,
+        children,
+    })
+}
+
+fn reconstruct_child_from_json(value: &Value) -> Result<XmlNode> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("Expected JSON object in _children array"))?;
+
+    let tag = obj
+        .get("_tag")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing _tag in _children element"))?
+        .to_string();
+
+    // Check if this has _children or _text (recursive structure)
+    let has_children_arr = obj.contains_key("_children");
+    let has_ns = obj.contains_key("_ns");
+    let has_attrs = obj.contains_key("_attrs");
+
+    if has_children_arr || has_ns || has_attrs {
+        // Full recursive node
+        return json_value_to_node(value);
+    }
+
+    // Check for _text (text leaf)
+    if let Some(text_val) = obj.get("_text") {
+        let text = json_value_to_string(text_val);
+        return Ok(XmlNode {
+            tag,
+            namespace: None,
+            attrs: IndexMap::new(),
+            children: if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![XmlValue::Text(text)]
+            },
+        });
+    }
+
+    // Otherwise it's a kv container: keys besides _tag are child elements
+    let mut children = Vec::new();
+    for (k, v) in obj {
+        if k == "_tag" {
+            continue;
+        }
+        let text = json_value_to_string(v);
+        children.push(XmlValue::Node(XmlNode {
+            tag: k.clone(),
+            namespace: None,
+            attrs: IndexMap::new(),
+            children: if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![XmlValue::Text(text)]
+            },
+        }));
+    }
+
+    Ok(XmlNode {
+        tag,
+        namespace: None,
+        attrs: IndexMap::new(),
+        children,
+    })
+}
+
+fn reconstruct_named_child_from_json(tag: &str, value: &Value) -> Result<XmlNode> {
+    match value {
+        Value::Object(m) => {
+            if m.contains_key("_tag") {
+                // Has its own tag — just parse as a full node
+                json_value_to_node(value)
+            } else {
+                // kv node without _tag
+                let mut children = Vec::new();
+                for (k, v) in m {
+                    let text = json_value_to_string(v);
+                    children.push(XmlValue::Node(XmlNode {
+                        tag: k.clone(),
+                        namespace: None,
+                        attrs: IndexMap::new(),
+                        children: if text.is_empty() {
+                            Vec::new()
+                        } else {
+                            vec![XmlValue::Text(text)]
+                        },
+                    }));
+                }
+                Ok(XmlNode {
+                    tag: tag.to_string(),
+                    namespace: None,
+                    attrs: IndexMap::new(),
+                    children,
+                })
+            }
+        }
+        _ => Ok(XmlNode {
+            tag: tag.to_string(),
+            namespace: None,
+            attrs: IndexMap::new(),
+            children: vec![XmlValue::Text(json_value_to_string(value))],
+        }),
+    }
+}
+
+fn json_value_to_string(val: &Value) -> String {
+    match val {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => String::new(),
+        _ => val.to_string(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 mod config;
 mod convert;
+mod json_writer;
 mod manifest;
 mod mcp;
+mod metadata_types;
 mod xml_parser;
 mod yaml_writer;
 
@@ -23,19 +25,23 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Convert Salesforce XML metadata to compact YAML
+    /// Convert Salesforce XML metadata to compact YAML or JSON
     Pack {
         /// Source path: directory or specific file(s)
         #[arg(default_value = "force-app")]
         source: Vec<PathBuf>,
 
-        /// Output directory for compact YAML files
+        /// Output directory for compact files
         #[arg(short, long, default_value = ".sf-compact")]
         output: PathBuf,
 
         /// Only include files matching this glob pattern (e.g. "profiles/**", "*.profile-meta.xml")
         #[arg(long)]
         include: Option<String>,
+
+        /// Output format override (yaml or json). Takes precedence over config.
+        #[arg(long)]
+        format: Option<String>,
     },
     /// Convert compact YAML back to Salesforce XML metadata (semantically lossless)
     Unpack {
@@ -121,10 +127,12 @@ fn main() -> Result<()> {
             source,
             output,
             include,
+            format,
         } => {
             let opts = convert::ConvertOpts {
                 paths: source,
                 include,
+                format_override: format,
             };
             let stats = convert::pack(&opts, &output)?;
             println!(
@@ -144,6 +152,7 @@ fn main() -> Result<()> {
             let opts = convert::ConvertOpts {
                 paths: source,
                 include,
+                format_override: None,
             };
             let stats = convert::unpack(&opts, &output)?;
             println!("Unpacked {} files", stats.files_processed);
@@ -156,6 +165,7 @@ fn main() -> Result<()> {
             let opts = convert::ConvertOpts {
                 paths: source,
                 include,
+                format_override: None,
             };
             let stats = convert::stats(&opts)?;
 
@@ -257,7 +267,7 @@ fn main() -> Result<()> {
 }
 
 fn config_init() -> Result<()> {
-    let entries = manifest::metadata_info_for_config();
+    let entries = metadata_types::metadata_info_for_config();
     let cfg = config::SfCompactConfig::with_smart_defaults(&entries);
     let path = config::save_config_to_dir(&cfg, &std::env::current_dir()?)?;
     println!("Created {}", path.display());

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::convert::SF_META_EXTENSIONS;
+use crate::metadata_types;
 
 #[derive(Serialize)]
 pub struct Manifest {
@@ -18,64 +18,13 @@ pub struct MetadataEntry {
     pub supported_formats: Vec<String>,
 }
 
-/// Map an extension to (type_name, category, order_sensitive).
-fn classify(ext: &str) -> (&str, &str, bool) {
-    match ext {
-        "profile-meta.xml" => ("Profile", "security", false),
-        "permissionset-meta.xml" => ("PermissionSet", "security", false),
-        "permissionsetgroup-meta.xml" => ("PermissionSetGroup", "security", false),
-        "object-meta.xml" => ("CustomObject", "schema", false),
-        "field-meta.xml" => ("CustomField", "schema", false),
-        "validationRule-meta.xml" => ("ValidationRule", "schema", false),
-        "flow-meta.xml" => ("Flow", "automation", true),
-        "layout-meta.xml" => ("Layout", "ui", true),
-        "labels-meta.xml" => ("CustomLabels", "ui", false),
-        "cls-meta.xml" => ("ApexClass", "code", false),
-        "trigger-meta.xml" => ("ApexTrigger", "code", false),
-        "component-meta.xml" => ("ApexComponent", "code", false),
-        "page-meta.xml" => ("ApexPage", "code", false),
-        "js-meta.xml" => ("LightningComponentBundle", "code", false),
-        "css-meta.xml" => ("LightningComponentBundle", "code", false),
-        "html-meta.xml" => ("LightningComponentBundle", "code", false),
-        "xml-meta.xml" => ("LightningComponentBundle", "code", false),
-        "email-meta.xml" => ("EmailTemplate", "content", false),
-        "workflow-meta.xml" => ("Workflow", "automation", false),
-        "app-meta.xml" => ("CustomApplication", "ui", false),
-        "tab-meta.xml" => ("CustomTab", "ui", false),
-        "flexipage-meta.xml" => ("FlexiPage", "ui", true),
-        "site-meta.xml" => ("CustomSite", "ui", false),
-        "remoteSite-meta.xml" => ("RemoteSiteSetting", "security", false),
-        "cspTrustedSite-meta.xml" => ("CspTrustedSite", "security", false),
-        "connectedApp-meta.xml" => ("ConnectedApp", "security", false),
-        "customMetadata-meta.xml" => ("CustomMetadata", "schema", false),
-        "globalValueSet-meta.xml" => ("GlobalValueSet", "schema", false),
-        "standardValueSet-meta.xml" => ("StandardValueSet", "schema", false),
-        "quickAction-meta.xml" => ("QuickAction", "ui", false),
-        "reportType-meta.xml" => ("ReportType", "analytics", false),
-        "report-meta.xml" => ("Report", "analytics", false),
-        "dashboard-meta.xml" => ("Dashboard", "analytics", false),
-        "pathAssistant-meta.xml" => ("PathAssistant", "ui", false),
-        "listView-meta.xml" => ("ListView", "ui", false),
-        "recordType-meta.xml" => ("RecordType", "schema", false),
-        "compactLayout-meta.xml" => ("CompactLayout", "ui", false),
-        "webLink-meta.xml" => ("WebLink", "ui", false),
-        "sharingRules-meta.xml" => ("SharingRules", "security", false),
-        "assignmentRules-meta.xml" => ("AssignmentRules", "automation", false),
-        "autoResponseRules-meta.xml" => ("AutoResponseRules", "automation", false),
-        "escalationRules-meta.xml" => ("EscalationRules", "automation", false),
-        "matchingRule-meta.xml" => ("MatchingRule", "schema", false),
-        "duplicateRule-meta.xml" => ("DuplicateRule", "schema", false),
-        _ => ("Unknown", "other", false),
-    }
-}
-
 pub fn build_manifest() -> Manifest {
-    let entries = SF_META_EXTENSIONS
+    let entries = metadata_types::METADATA_TYPES
         .iter()
-        .map(|ext| {
-            let (meta_type, category, order_sensitive) = classify(ext);
+        .map(|t| {
+            let (meta_type, category, order_sensitive) = metadata_types::classify(t.extension);
             MetadataEntry {
-                extension: ext.to_string(),
+                extension: t.extension.to_string(),
                 meta_type: meta_type.to_string(),
                 category: category.to_string(),
                 order_sensitive,
@@ -88,22 +37,4 @@ pub fn build_manifest() -> Manifest {
         version: env!("CARGO_PKG_VERSION").to_string(),
         supported_metadata: entries,
     }
-}
-
-/// Return a list of (type_name, order_sensitive, supported_formats) for config init.
-pub fn metadata_info_for_config() -> Vec<(String, bool, Vec<String>)> {
-    let manifest = build_manifest();
-    let mut seen = std::collections::HashSet::new();
-    let mut result = Vec::new();
-    for entry in manifest.supported_metadata {
-        // Deduplicate by type name (e.g. LightningComponentBundle appears multiple times)
-        if seen.insert(entry.meta_type.clone()) {
-            result.push((
-                entry.meta_type,
-                entry.order_sensitive,
-                entry.supported_formats,
-            ));
-        }
-    }
-    result
 }

--- a/src/metadata_types.rs
+++ b/src/metadata_types.rs
@@ -1,0 +1,315 @@
+/// Single source of truth for all supported Salesforce metadata types.
+/// Every other module derives its metadata knowledge from this array.
+pub struct MetadataTypeDef {
+    pub extension: &'static str,
+    pub meta_type: &'static str,
+    pub category: &'static str,
+    pub order_sensitive: bool,
+}
+
+pub static METADATA_TYPES: &[MetadataTypeDef] = &[
+    MetadataTypeDef {
+        extension: "profile-meta.xml",
+        meta_type: "Profile",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "permissionset-meta.xml",
+        meta_type: "PermissionSet",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "permissionsetgroup-meta.xml",
+        meta_type: "PermissionSetGroup",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "object-meta.xml",
+        meta_type: "CustomObject",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "field-meta.xml",
+        meta_type: "CustomField",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "validationRule-meta.xml",
+        meta_type: "ValidationRule",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "flow-meta.xml",
+        meta_type: "Flow",
+        category: "automation",
+        order_sensitive: true,
+    },
+    MetadataTypeDef {
+        extension: "layout-meta.xml",
+        meta_type: "Layout",
+        category: "ui",
+        order_sensitive: true,
+    },
+    MetadataTypeDef {
+        extension: "labels-meta.xml",
+        meta_type: "CustomLabels",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "cls-meta.xml",
+        meta_type: "ApexClass",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "trigger-meta.xml",
+        meta_type: "ApexTrigger",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "component-meta.xml",
+        meta_type: "ApexComponent",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "page-meta.xml",
+        meta_type: "ApexPage",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "js-meta.xml",
+        meta_type: "LightningComponentBundle",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "css-meta.xml",
+        meta_type: "LightningComponentBundle",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "html-meta.xml",
+        meta_type: "LightningComponentBundle",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "xml-meta.xml",
+        meta_type: "LightningComponentBundle",
+        category: "code",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "email-meta.xml",
+        meta_type: "EmailTemplate",
+        category: "content",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "workflow-meta.xml",
+        meta_type: "Workflow",
+        category: "automation",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "app-meta.xml",
+        meta_type: "CustomApplication",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "tab-meta.xml",
+        meta_type: "CustomTab",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "flexipage-meta.xml",
+        meta_type: "FlexiPage",
+        category: "ui",
+        order_sensitive: true,
+    },
+    MetadataTypeDef {
+        extension: "site-meta.xml",
+        meta_type: "CustomSite",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "remoteSite-meta.xml",
+        meta_type: "RemoteSiteSetting",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "cspTrustedSite-meta.xml",
+        meta_type: "CspTrustedSite",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "connectedApp-meta.xml",
+        meta_type: "ConnectedApp",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "customMetadata-meta.xml",
+        meta_type: "CustomMetadata",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "globalValueSet-meta.xml",
+        meta_type: "GlobalValueSet",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "standardValueSet-meta.xml",
+        meta_type: "StandardValueSet",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "quickAction-meta.xml",
+        meta_type: "QuickAction",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "reportType-meta.xml",
+        meta_type: "ReportType",
+        category: "analytics",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "report-meta.xml",
+        meta_type: "Report",
+        category: "analytics",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "dashboard-meta.xml",
+        meta_type: "Dashboard",
+        category: "analytics",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "pathAssistant-meta.xml",
+        meta_type: "PathAssistant",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "listView-meta.xml",
+        meta_type: "ListView",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "recordType-meta.xml",
+        meta_type: "RecordType",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "compactLayout-meta.xml",
+        meta_type: "CompactLayout",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "webLink-meta.xml",
+        meta_type: "WebLink",
+        category: "ui",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "sharingRules-meta.xml",
+        meta_type: "SharingRules",
+        category: "security",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "assignmentRules-meta.xml",
+        meta_type: "AssignmentRules",
+        category: "automation",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "autoResponseRules-meta.xml",
+        meta_type: "AutoResponseRules",
+        category: "automation",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "escalationRules-meta.xml",
+        meta_type: "EscalationRules",
+        category: "automation",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "matchingRule-meta.xml",
+        meta_type: "MatchingRule",
+        category: "schema",
+        order_sensitive: false,
+    },
+    MetadataTypeDef {
+        extension: "duplicateRule-meta.xml",
+        meta_type: "DuplicateRule",
+        category: "schema",
+        order_sensitive: false,
+    },
+];
+
+/// Classify an extension into (type_name, category, order_sensitive).
+pub fn classify(ext: &str) -> (&'static str, &'static str, bool) {
+    METADATA_TYPES
+        .iter()
+        .find(|t| t.extension == ext)
+        .map(|t| (t.meta_type, t.category, t.order_sensitive))
+        .unwrap_or(("Unknown", "other", false))
+}
+
+/// Return deduplicated list of (type_name, order_sensitive, supported_formats) for config init.
+pub fn metadata_info_for_config() -> Vec<(String, bool, Vec<String>)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut result = Vec::new();
+    for t in METADATA_TYPES {
+        if seen.insert(t.meta_type) {
+            result.push((
+                t.meta_type.to_string(),
+                t.order_sensitive,
+                vec!["yaml".to_string(), "json".to_string()],
+            ));
+        }
+    }
+    result
+}
+
+/// Check if a filename matches any known SF metadata extension.
+pub fn is_sf_metadata_filename(name: &str) -> bool {
+    METADATA_TYPES.iter().any(|t| name.ends_with(t.extension))
+}
+
+/// Look up the manifest type name for a short extension type (e.g., "flow" -> "Flow").
+pub fn manifest_type_for_short(short_type: &str) -> String {
+    let ext = format!("{short_type}-meta.xml");
+    METADATA_TYPES
+        .iter()
+        .find(|t| t.extension == ext)
+        .map(|t| t.meta_type.to_string())
+        .unwrap_or_else(|| short_type.to_string())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -615,6 +615,321 @@ fn manifest_includes_order_sensitive() {
     );
 }
 
+// ─── JSON format tests ──────────────────────────────────────────
+
+#[test]
+fn pack_json_format() {
+    let fixtures = Path::new("tests/fixtures");
+    let packed = tempfile::tempdir().unwrap();
+
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to run pack with --format json");
+    assert!(
+        output.status.success(),
+        "pack --format json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packed 5 files"),
+        "unexpected pack output: {stdout}"
+    );
+
+    // Verify .json files were created (not .yaml)
+    let json_profile = packed
+        .path()
+        .join("force-app/main/default/profiles/Admin.profile-meta.json");
+    assert!(
+        json_profile.exists(),
+        "JSON profile file not created at {}",
+        json_profile.display()
+    );
+
+    // Verify it's valid JSON
+    let content = std::fs::read_to_string(&json_profile).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("Output is not valid JSON");
+    assert_eq!(
+        parsed.get("_tag").and_then(|v| v.as_str()),
+        Some("Profile"),
+        "JSON should have _tag: Profile"
+    );
+}
+
+#[test]
+fn json_roundtrip() {
+    let fixtures = Path::new("tests/fixtures");
+    let packed = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Pack as JSON
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to pack as JSON");
+    assert!(
+        output.status.success(),
+        "pack json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Unpack back to XML
+    let output = sf_compact()
+        .args([
+            "unpack",
+            packed.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to unpack JSON");
+    assert!(
+        output.status.success(),
+        "unpack JSON failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unpacked 5 files"),
+        "unexpected unpack output: {stdout}"
+    );
+
+    // Verify restored XML
+    let xml_profile = unpacked
+        .path()
+        .join("force-app/main/default/profiles/Admin.profile-meta.xml");
+    assert!(xml_profile.exists(), "XML profile not restored from JSON");
+
+    let content = std::fs::read_to_string(&xml_profile).unwrap();
+    assert!(
+        content.contains("<Profile"),
+        "restored XML missing Profile tag"
+    );
+    assert!(
+        content.contains("http://soap.sforce.com/2006/04/metadata"),
+        "restored XML missing namespace"
+    );
+}
+
+#[test]
+fn json_preserves_element_order() {
+    // The flow fixture has two <assignments> elements in a specific order.
+    // JSON format should preserve that order via _children arrays.
+    let flow_xml = std::fs::read_to_string(
+        "tests/fixtures/force-app/main/default/flows/Case_Assignment.flow-meta.xml",
+    )
+    .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let xml_path = dir.path().join("Case_Assignment.flow-meta.xml");
+    std::fs::write(&xml_path, &flow_xml).unwrap();
+
+    let packed = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Pack as JSON
+    let output = sf_compact()
+        .args([
+            "pack",
+            xml_path.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to pack flow as JSON");
+    assert!(output.status.success(), "pack json failed");
+
+    // Verify JSON has _children array preserving order
+    let json_path = packed.path().join("Case_Assignment.flow-meta.json");
+    assert!(json_path.exists(), "JSON flow file not created");
+    let json_content = std::fs::read_to_string(&json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json_content).unwrap();
+
+    // _children should be an array
+    let children = parsed
+        .get("_children")
+        .and_then(|v| v.as_array())
+        .expect("JSON should have _children array");
+
+    // Find the assignments in order — High_Priority_Assignment should come before Low_Priority_Assignment
+    let assignment_names: Vec<&str> = children
+        .iter()
+        .filter(|c| c.get("_tag").and_then(|t| t.as_str()) == Some("assignments"))
+        .filter_map(|c| {
+            c.get("_children")
+                .and_then(|ch| ch.as_array())
+                .and_then(|arr| {
+                    arr.iter().find_map(|item| {
+                        if item.get("_tag").and_then(|t| t.as_str()) == Some("name") {
+                            item.get("_text").and_then(|v| v.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                })
+        })
+        .collect();
+
+    assert_eq!(
+        assignment_names,
+        vec!["High_Priority_Assignment", "Low_Priority_Assignment"],
+        "JSON should preserve element order"
+    );
+
+    // Roundtrip back to XML and verify order
+    let output = sf_compact()
+        .args([
+            "unpack",
+            packed.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to unpack");
+    assert!(output.status.success());
+
+    let restored = unpacked.path().join("Case_Assignment.flow-meta.xml");
+    let restored_content = std::fs::read_to_string(&restored).unwrap();
+
+    // Verify that the <assignments> blocks appear in the correct order.
+    // We look for <name>High_Priority_Assignment</name> and <name>Low_Priority_Assignment</name>
+    // within the assignments context (not the defaultConnector references).
+    let high_assignment_pos = restored_content
+        .find("<name>High_Priority_Assignment</name>")
+        .expect("High_Priority_Assignment assignment not found");
+    let low_assignment_pos = restored_content
+        .find("<name>Low_Priority_Assignment</name>")
+        .expect("Low_Priority_Assignment assignment not found");
+    assert!(
+        high_assignment_pos < low_assignment_pos,
+        "Element order not preserved in JSON roundtrip: High at {}, Low at {}",
+        high_assignment_pos,
+        low_assignment_pos
+    );
+}
+
+#[test]
+fn pack_uses_config_format() {
+    let dir = tempfile::tempdir().unwrap();
+    let packed = tempfile::tempdir().unwrap();
+
+    // Create config that sets flow to json (everything else yaml)
+    let config_content = "default_format: yaml\nformats:\n  Flow: json\nskip: []\n";
+    std::fs::write(dir.path().join(".sfcompact.yaml"), config_content).unwrap();
+
+    // Copy test fixtures into the temp dir
+    let fixtures = std::path::Path::new("tests/fixtures");
+    copy_dir_recursive(fixtures, &dir.path().join("tests/fixtures"));
+
+    let output = sf_compact()
+        .args([
+            "pack",
+            dir.path().join("tests/fixtures").to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run pack with config format");
+    assert!(
+        output.status.success(),
+        "pack failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Flow should be .json
+    let flow_json = packed
+        .path()
+        .join("force-app/main/default/flows/Case_Assignment.flow-meta.json");
+    assert!(
+        flow_json.exists(),
+        "Flow should be packed as .json per config"
+    );
+
+    // Profile should still be .yaml
+    let profile_yaml = packed
+        .path()
+        .join("force-app/main/default/profiles/Admin.profile-meta.yaml");
+    assert!(
+        profile_yaml.exists(),
+        "Profile should still be .yaml per default config"
+    );
+}
+
+#[test]
+fn numeric_strings_preserved_json_roundtrip() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>0012</status>
+</ApexClass>"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let xml_path = dir.path().join("Test.cls-meta.xml");
+    std::fs::write(&xml_path, xml).unwrap();
+
+    let packed = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Pack as JSON
+    let output = sf_compact()
+        .args([
+            "pack",
+            xml_path.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to pack as JSON");
+    assert!(output.status.success(), "pack json failed");
+
+    // Unpack
+    let output = sf_compact()
+        .args([
+            "unpack",
+            packed.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to unpack");
+    assert!(output.status.success(), "unpack failed");
+
+    let restored = unpacked.path().join("Test.cls-meta.xml");
+    assert!(restored.exists(), "restored file not found");
+    let content = std::fs::read_to_string(&restored).unwrap();
+    assert!(
+        content.contains(">59.0<"),
+        "apiVersion 59.0 was corrupted in JSON roundtrip: {content}"
+    );
+    assert!(
+        content.contains(">0012<"),
+        "leading-zero string 0012 was corrupted in JSON roundtrip: {content}"
+    );
+}
+
 /// Helper to recursively copy a directory.
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
     std::fs::create_dir_all(dst).unwrap();


### PR DESCRIPTION
## Summary

**Metadata refactor:**
- New `src/metadata_types.rs` — single `METADATA_TYPES` static array replaces 3 duplicated definitions
- Removed hardcoded `SF_META_EXTENSIONS`, `classify()` match, and `metadata_info_for_config()`
- All metadata knowledge derived from one place

**JSON output format:**
- New `src/json_writer.rs` — XML to compact single-line JSON and back
- JSON uses `_children` arrays preserving exact element order (key for order-sensitive types)
- `--format yaml|json` flag on `pack` command
- Config-driven: per-type format selection via `.sfcompact.yaml`
- `unpack` auto-detects format by file extension (`.json` vs `.yaml`)

**5 new integration tests** (30 total): JSON pack, roundtrip, order preservation, config-driven format, numeric string preservation

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)