### PR TITLE
Update documentation for config system, JSON format, and yaml-ordered

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # sf-compact
 
-Convert Salesforce metadata XML to AI-friendly YAML and back. Semantically lossless roundtrip.
+Convert Salesforce metadata XML to AI-friendly compact formats. Semantically lossless roundtrip.
 
 Salesforce metadata XML is extremely verbose — profiles, permission sets, flows, and objects can be 20,000–50,000+ lines of XML with 70–85% structural overhead. This burns tokens and money when AI tools (Claude Code, Codex, Cursor, etc.) read or edit your metadata.
 
-**sf-compact** converts it to a compact YAML format that preserves all information but uses ~50% fewer tokens.
+**sf-compact** converts it to compact YAML or JSON, saving 42–54% of tokens depending on format.
+
+## Output Formats
+
+| Format | Preserves order | Human-readable | Token savings |
+|--------|:-:|:-:|:-:|
+| `yaml` | No | Yes | ~49% |
+| `yaml-ordered` | Yes | Yes | ~42% |
+| `json` | Yes | Less | ~54% |
+
+- **yaml** — groups repeated elements into arrays. Most compact YAML, but sibling order may change. Best for order-insensitive types (Profile, PermissionSet).
+- **yaml-ordered** — uses `_children` sequences to preserve exact element order. Best for order-sensitive types (Flow, FlexiPage, Layout).
+- **json** — compact single-line JSON with arrays. Preserves order, fewest tokens, less human-readable.
 
 ## Before / After
 
@@ -28,7 +40,7 @@ Salesforce metadata XML is extremely verbose — profiles, permission sets, flow
 </Profile>
 ```
 
-**YAML (432 tokens) — 49% reduction:**
+**YAML (432 tokens — 49% reduction):**
 ```yaml
 _tag: Profile
 _ns: http://soap.sforce.com/2006/04/metadata
@@ -42,6 +54,11 @@ fieldPermissions:
   field: Account.BillingCity
   readable: true
 ...
+```
+
+**JSON (389 tokens — 54% reduction):**
+```json
+{"_tag":"Profile","_ns":"http://soap.sforce.com/2006/04/metadata","custom":"false","userLicense":"Salesforce","fieldPermissions":[{"editable":"true","field":"Account.AnnualRevenue","readable":"true"},{"editable":"false","field":"Account.BillingCity","readable":"true"}]}
 ```
 
 ## Install
@@ -58,16 +75,17 @@ cargo install sf-compact
 
 ## Usage
 
-### Pack (XML → YAML)
+### Pack (XML → compact format)
 ```bash
-sf-compact pack [source...] [-o output]
+sf-compact pack [source...] [-o output] [--format yaml|yaml-ordered|json] [--include pattern]
 ```
 
-Convert Salesforce metadata XML to compact YAML.
-
 ```bash
-# Pack entire project
+# Pack entire project (default: YAML format)
 sf-compact pack force-app -o .sf-compact
+
+# Pack as JSON for maximum token savings
+sf-compact pack force-app --format json
 
 # Pack specific directories
 sf-compact pack force-app/main/default/profiles force-app/main/default/classes
@@ -76,12 +94,12 @@ sf-compact pack force-app/main/default/profiles force-app/main/default/classes
 sf-compact pack force-app --include "*.profile-meta.xml"
 ```
 
-### Unpack (YAML → XML)
+### Unpack (compact format → XML)
 ```bash
-sf-compact unpack [source...] [-o output]
+sf-compact unpack [source...] [-o output] [--include pattern]
 ```
 
-Convert compact YAML back to Salesforce metadata XML (semantically lossless).
+Auto-detects format by file extension (`.yaml` or `.json`).
 
 ```bash
 sf-compact unpack .sf-compact -o force-app
@@ -119,6 +137,40 @@ Tokenizer: cl100k_base (GPT-4 / Claude)
 
 Use `--files` for per-file breakdown, `--include` to filter by glob pattern.
 
+### Configuration
+
+sf-compact uses a `.sfcompact.yaml` config file for per-type format control.
+
+```bash
+# Create config with smart defaults (yaml-ordered for order-sensitive types)
+sf-compact config init
+
+# Set format for specific types (batch — multiple types in one call)
+sf-compact config set flow json profile yaml flexipage yaml-ordered
+
+# Change default format for all types
+sf-compact config set default json
+
+# Skip a metadata type from conversion
+sf-compact config skip customMetadata
+
+# View current configuration
+sf-compact config show
+```
+
+Default config after `config init`:
+
+```yaml
+default_format: yaml
+formats:
+  Flow: yaml-ordered
+  FlexiPage: yaml-ordered
+  Layout: yaml-ordered
+skip: []
+```
+
+When `pack` runs, it reads `.sfcompact.yaml` and applies the format per metadata type. The `--format` CLI flag overrides the config for a single run.
+
 ### MCP Server
 
 sf-compact includes a built-in [MCP](https://modelcontextprotocol.io/) server for direct AI tool integration.
@@ -144,7 +196,7 @@ sf-compact init instructions --name SALESFORCE.md
 
 ### Manifest
 
-Output supported metadata types in JSON:
+Output supported metadata types in JSON (includes format support and order-sensitivity flags):
 
 ```bash
 sf-compact manifest
@@ -152,36 +204,39 @@ sf-compact manifest
 
 ## Supported Metadata Types
 
-46 file extensions mapping to 41 unique Salesforce metadata types across 7 categories:
+44 file extensions mapping to 41 unique Salesforce metadata types across 7 categories:
 
 | Category | Types |
 |----------|-------|
 | **Security** | Profile, PermissionSet, PermissionSetGroup, RemoteSiteSetting, CspTrustedSite, ConnectedApp, SharingRules |
 | **Schema** | CustomObject, CustomField, ValidationRule, CustomMetadata, GlobalValueSet, StandardValueSet, RecordType, MatchingRule, DuplicateRule |
 | **Code** | ApexClass, ApexTrigger, ApexComponent, ApexPage, LightningComponentBundle (js/css/html/xml) |
-| **Automation** | Flow, Workflow, AssignmentRules, AutoResponseRules, EscalationRules |
-| **UI** | Layout, CustomLabels, CustomApplication, CustomTab, FlexiPage, CustomSite, QuickAction, PathAssistant, ListView, CompactLayout, WebLink |
+| **Automation** | Flow*, Workflow, AssignmentRules, AutoResponseRules, EscalationRules |
+| **UI** | Layout*, CustomLabels, CustomApplication, CustomTab, FlexiPage*, CustomSite, QuickAction, PathAssistant, ListView, CompactLayout, WebLink |
 | **Analytics** | ReportType, Report, Dashboard |
 | **Content** | EmailTemplate |
 
+\* Order-sensitive types — `config init` defaults these to `yaml-ordered` to preserve element order.
+
 ## Workflow
 
-1. **Pull metadata** from Salesforce (`sf project retrieve`)
-2. **Pack**: `sf-compact pack` — creates `.sf-compact/` with YAML versions
-3. **Work with YAML** — let AI tools read/edit the compact format
-4. **Unpack**: `sf-compact unpack` — restores XML for deployment
-5. **Deploy** to Salesforce (`sf project deploy`)
+1. **Configure** (once): `sf-compact config init` — creates `.sfcompact.yaml` with smart defaults
+2. **Pull metadata** from Salesforce (`sf project retrieve`)
+3. **Pack**: `sf-compact pack` — creates `.sf-compact/` with compact files
+4. **Work with compact files** — let AI tools read/edit the YAML/JSON format
+5. **Unpack**: `sf-compact unpack` — restores XML for deployment
+6. **Deploy** to Salesforce (`sf project deploy`)
 
 > Tip: Add `.sf-compact/` to `.gitignore` if you treat it as a build artifact, or commit it for AI-friendly diffs.
 
 ## How it works
 
 - Parses Salesforce metadata XML into a tree structure
-- Groups repeated elements (e.g., `<fieldPermissions>`) into YAML arrays
-- Coerces types: `"true"` → `true`, `"59.0"` → `59.0`
-- Flattens simple key-value containers into inline YAML mappings
+- Groups repeated elements (e.g., `<fieldPermissions>`) into arrays (YAML) or `_children` sequences (yaml-ordered, JSON)
+- Coerces booleans: `"true"` → `true`, `"false"` → `false`. All other values (including numeric strings like `"59.0"`, `"0012"`) are preserved as-is
+- Flattens simple key-value containers into inline mappings
 - Preserves namespaces, attributes, and all structural information for semantically lossless roundtrip
-- **Note:** element ordering within a parent may change. Salesforce metadata API does not guarantee element order, so this is semantically equivalent
+- Order-sensitive types (Flow, FlexiPage, Layout) default to `yaml-ordered` format, which preserves exact element order via `_children` sequences
 
 Token counting uses the `cl100k_base` tokenizer (same family used by GPT-4 and Claude).
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -266,68 +266,61 @@ pub fn generate_instructions() -> String {
 
 ## What is sf-compact?
 
-sf-compact converts Salesforce metadata XML files into a compact YAML format that is semantically equivalent but uses significantly fewer tokens. This reduces cost and improves performance when AI tools read or analyze Salesforce metadata.
+sf-compact converts Salesforce metadata XML files into compact YAML or JSON formats that are semantically equivalent but use significantly fewer tokens (42–54% reduction). This reduces cost and improves performance when AI tools read or analyze Salesforce metadata.
 
-The conversion is **lossless** — you can always convert back to the original XML format.
+The conversion is **semantically lossless** — you can always convert back to XML. Element order within a parent may change unless you use `yaml-ordered` or `json` format.
+
+## Output Formats
+
+- **yaml** — grouped arrays, ~49% token savings, best for order-insensitive types
+- **yaml-ordered** — `_children` sequences, ~42% savings, preserves element order
+- **json** — compact single-line, ~54% savings, preserves order
 
 ## Available Commands
 
-### Pack (XML to YAML)
+### Pack (XML to compact format)
 ```bash
-sf-compact pack [source] [-o output]
+sf-compact pack [source...] [-o output] [--format yaml|yaml-ordered|json] [--include pattern]
 ```
-Convert Salesforce metadata XML to compact YAML.
-- `source` — directory with XML files (default: `force-app`)
+- `source` — one or more directories or files (default: `force-app`)
 - `-o output` — output directory (default: `.sf-compact`)
+- `--format` — output format override (default: from config or `yaml`)
+- `--include` — glob filter (e.g. `"*.profile-meta.xml"`)
 
-**Example:**
+### Unpack (compact format to XML)
 ```bash
-sf-compact pack force-app -o .sf-compact
+sf-compact unpack [source...] [-o output] [--include pattern]
 ```
-
-### Unpack (YAML to XML)
-```bash
-sf-compact unpack [source] [-o output]
-```
-Convert compact YAML back to Salesforce metadata XML.
-- `source` — directory with YAML files (default: `.sf-compact`)
-- `-o output` — output directory (default: `force-app`)
-
-**Example:**
-```bash
-sf-compact unpack .sf-compact -o force-app
-```
+Auto-detects format by file extension (`.yaml` or `.json`).
 
 ### Stats
 ```bash
-sf-compact stats [source]
+sf-compact stats [source...] [--include pattern] [--files]
 ```
-Analyze metadata and show token/byte savings.
+Preview token/byte savings without writing files.
 
-**Example:**
+### Configuration
 ```bash
-sf-compact stats force-app
+sf-compact config init                              # create .sfcompact.yaml with smart defaults
+sf-compact config set flow json profile yaml        # batch set formats per type
+sf-compact config set default json                  # change default format
+sf-compact config skip customMetadata               # exclude a type
+sf-compact config show                              # display config
 ```
 
-### Manifest
-```bash
-sf-compact manifest
-```
-Output supported metadata types in JSON format.
+### Other Commands
+- `sf-compact manifest` — output supported metadata types in JSON
+- `sf-compact mcp-serve` — start MCP server over stdio
+- `sf-compact init mcp` — create/update .mcp.json
+- `sf-compact init instructions` — generate AI instructions markdown
 
-### MCP Server
-```bash
-sf-compact mcp-serve
-```
-Start the MCP (Model Context Protocol) server over stdio for tool integration.
+## Workflow
 
-## Workflow Instructions
-
-1. **Always work with YAML files** in `.sf-compact/` for reading and editing metadata.
-2. **Run `sf-compact pack`** after pulling metadata from Salesforce to create compact versions.
-3. **Edit the YAML files** — they are the working copies.
-4. **Run `sf-compact unpack` before deploy** to convert YAML back to XML that Salesforce CLI expects.
-5. **Add `.sf-compact/` to `.gitignore`** if you prefer to treat it as a build artifact, or commit it for AI-friendly diffs.
+1. **Configure** (once): `sf-compact config init`
+2. **Run `sf-compact pack`** after pulling metadata from Salesforce.
+3. **Work with compact files** in `.sf-compact/` — let AI tools read/edit them.
+4. **Run `sf-compact unpack` before deploy** to restore XML.
+5. **Add `.sf-compact/` to `.gitignore`** if you prefer to treat it as a build artifact.
 
 ## Supported Metadata Types
 


### PR DESCRIPTION
## Summary

Full documentation update after implementing config system (#2), JSON format (#3), yaml-ordered (#4), and release workflow (#6).

**README.md:**
- Added output formats comparison table (yaml / yaml-ordered / json with token savings)
- Added JSON before/after example
- Documented `config` commands (init, set batch, skip, show)
- Documented `--format` flag on pack
- Fixed extension count: 44 (was incorrectly 46)
- Fixed type coercion description: only booleans coerced, numeric strings preserved as-is
- Marked order-sensitive types with asterisk (Flow, FlexiPage, Layout)
- Updated workflow to include `config init` step

**MCP instructions generator (src/mcp.rs):**
- Updated to cover all three output formats
- Documented config commands
- Changed "lossless" to "semantically lossless"

🤖 Generated with [Claude Code](https://claude.com/claude-code)