### PR TITLE
Fix MCP fake token count and unpack crash on invalid files

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -409,11 +409,27 @@ pub fn unpack(opts: &ConvertOpts, output: &Path) -> Result<ConvertStats> {
             .is_some_and(|n| n.ends_with("-meta.json"));
 
         let node = if is_json {
-            json_writer::json_to_xml_node(&content)
-                .with_context(|| format!("Parsing JSON {}", compact_path.display()))?
+            match json_writer::json_to_xml_node(&content) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: skipping {} (not valid sf-compact JSON: {e})",
+                        compact_path.display()
+                    );
+                    continue;
+                }
+            }
         } else {
-            yaml_writer::yaml_to_xml_node(&content)
-                .with_context(|| format!("Parsing YAML {}", compact_path.display()))?
+            match yaml_writer::yaml_to_xml_node(&content) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: skipping {} (not valid sf-compact YAML: {e})",
+                        compact_path.display()
+                    );
+                    continue;
+                }
+            }
         };
 
         let xml = xml_parser::to_xml(&node);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -181,12 +181,11 @@ fn call_pack(args: &Value) -> Result<Value> {
     let stats = convert::pack_path(Path::new(source), Path::new(output))?;
 
     let text = format!(
-        "Packed {} files: {} -> {} bytes ({:.1}% reduction, ~{} tokens saved)",
+        "Packed {} files: {} -> {} bytes ({:.1}% reduction)",
         stats.files_processed,
         stats.original_bytes,
         stats.compact_bytes,
         stats.reduction_percent(),
-        stats.tokens_saved(),
     );
 
     Ok(json!({

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1204,6 +1204,58 @@ _children:
     assert!(content.contains(">59.0<"), "ordered XML missing apiVersion");
 }
 
+// ─── Bug fix tests ──────────────────────────────────────────────
+
+#[test]
+fn unpack_skips_invalid_sf_compact_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Create a file that matches -meta.yaml naming but has no _tag (not sf-compact)
+    std::fs::write(
+        dir.path().join("SomeObject.object-meta.yaml"),
+        "description: just a random YAML\nfields:\n- name: foo\n",
+    )
+    .unwrap();
+
+    // Also create a valid sf-compact file
+    std::fs::write(
+        dir.path().join("Test.cls-meta.yaml"),
+        "_tag: ApexClass\n_ns: http://soap.sforce.com/2006/04/metadata\napiVersion: '59.0'\nstatus: Active\n",
+    )
+    .unwrap();
+
+    let output = sf_compact()
+        .args([
+            "unpack",
+            dir.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run unpack");
+
+    // Should succeed (not crash) even with invalid file present
+    assert!(
+        output.status.success(),
+        "unpack should not crash on invalid sf-compact files: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unpacked 1 files"),
+        "should only unpack valid sf-compact file, got: {stdout}"
+    );
+
+    // Should have a warning on stderr about the skipped file
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Warning: skipping"),
+        "should warn about skipped file, stderr: {stderr}"
+    );
+}
+
 /// Helper to recursively copy a directory.
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
     std::fs::create_dir_all(dst).unwrap();


### PR DESCRIPTION
## Summary
- Remove fake "~0 tokens saved" from MCP `call_pack()` output — pack doesn't count tokens, so the message was always wrong
- Gracefully skip non-sf-compact files during unpack instead of crashing with "Missing _tag" — now prints a warning and continues
- Added integration test for unpack resilience

Fixes #12, fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)