### PR TITLE
Add watch, diff commands and unpack --include

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,6 +87,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -170,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -191,10 +197,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "getrandom"
@@ -255,6 +281,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +320,26 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -285,6 +360,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +390,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +452,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "prettyplease"
@@ -358,6 +503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,11 +552,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -490,6 +644,8 @@ dependencies = [
  "clap",
  "glob",
  "indexmap",
+ "notify",
+ "notify-debouncer-mini",
  "quick-xml",
  "serde",
  "serde_json",
@@ -526,7 +682,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -579,6 +735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,7 +786,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -636,7 +798,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -647,12 +809,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -712,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ anyhow = "1"
 indexmap = { version = "2", features = ["serde"] }
 tiktoken-rs = "0.9.1"
 glob = "0.3"
+notify = { version = "7", features = ["macos_fsevent"] }
+notify-debouncer-mini = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fieldPermissions:
 cargo install --path .
 ```
 
-### From crates.io (coming soon)
+### From crates.io
 ```bash
 cargo install sf-compact
 ```
@@ -171,6 +171,38 @@ skip: []
 
 When `pack` runs, it reads `.sfcompact.yaml` and applies the format per metadata type. The `--format` CLI flag overrides the config for a single run.
 
+### Watch (auto-pack on changes)
+```bash
+sf-compact watch [source...] [-o output] [--format yaml|yaml-ordered|json] [--include pattern]
+```
+
+Watches source directories for XML changes and automatically repacks. Runs an initial pack, then monitors for file changes.
+
+```bash
+# Watch default force-app directory
+sf-compact watch
+
+# Watch with JSON format
+sf-compact watch force-app --format json
+```
+
+### Diff (detect unpacked changes)
+```bash
+sf-compact diff [source...] [-o packed-dir] [--include pattern]
+```
+
+Compare current XML metadata against the last packed output. Shows new, modified, and deleted files.
+
+```bash
+$ sf-compact diff
+
+  + force-app/main/default/profiles/NewProfile.profile-meta.xml  (new — not yet packed)
+  ~ force-app/main/default/flows/Case_Assignment.flow-meta.xml  (modified since last pack)
+
+1 new, 1 modified, 0 deleted, 3 unchanged
+Run `sf-compact pack` to update.
+```
+
 ### MCP Server
 
 sf-compact includes a built-in [MCP](https://modelcontextprotocol.io/) server for direct AI tool integration.
@@ -226,6 +258,8 @@ sf-compact manifest
 4. **Work with compact files** — let AI tools read/edit the YAML/JSON format
 5. **Unpack**: `sf-compact unpack` — restores XML for deployment
 6. **Deploy** to Salesforce (`sf project deploy`)
+
+> Use `sf-compact watch` during development to auto-pack on changes, and `sf-compact diff` to check if a repack is needed.
 
 > Tip: Add `.sf-compact/` to `.gitignore` if you treat it as a build artifact, or commit it for AI-friendly diffs.
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -516,6 +516,48 @@ pub fn unpack_path(source: &Path, output: &Path) -> Result<ConvertStats> {
     )
 }
 
+// ─── Public accessors for diff module ────────────────────────────
+
+/// Find SF metadata XML files (public for diff).
+pub fn find_sf_xml_files(opts: &ConvertOpts) -> Vec<PathBuf> {
+    find_sf_xml_files_from_opts(opts)
+}
+
+/// Find compact files (public for diff).
+pub fn find_compact_files(opts: &ConvertOpts) -> Vec<PathBuf> {
+    find_compact_files_from_opts(opts)
+}
+
+/// Common root (public for diff).
+pub fn common_root_from_opts(opts: &ConvertOpts) -> PathBuf {
+    common_root(opts)
+}
+
+/// Metadata type for a path (public for diff).
+pub fn metadata_type_for(path: &Path) -> String {
+    metadata_type(path)
+}
+
+/// Effective format (public for diff).
+pub fn effective_format_for(
+    short_type: &str,
+    type_name: &str,
+    cfg: &config::SfCompactConfig,
+    cli_override: &Option<String>,
+) -> String {
+    effective_format(short_type, type_name, cfg, cli_override)
+}
+
+/// Compact path for XML (public for diff).
+pub fn compact_path_for(
+    xml_path: &Path,
+    source_root: &Path,
+    output_root: &Path,
+    format: &str,
+) -> PathBuf {
+    compact_path_for_xml(xml_path, source_root, output_root, format)
+}
+
 fn accumulate_stats(
     stats: &mut ConvertStats,
     xml_path: &Path,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,125 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config;
+use crate::convert;
+use crate::json_writer;
+use crate::metadata_types;
+use crate::xml_parser;
+use crate::yaml_writer;
+
+pub struct DiffResult {
+    pub new_files: Vec<String>,
+    pub modified_files: Vec<String>,
+    pub deleted_files: Vec<String>,
+    pub unchanged_files: usize,
+}
+
+/// Compare current XML metadata against packed compact files.
+/// Shows which files are new, modified, or deleted since last pack.
+pub fn diff(sources: &[PathBuf], packed_dir: &Path, include: Option<&str>) -> Result<DiffResult> {
+    // Validate
+    for p in sources {
+        if !p.exists() {
+            anyhow::bail!("Path not found: {}", p.display());
+        }
+    }
+
+    let opts = convert::ConvertOpts {
+        paths: sources.to_vec(),
+        include: include.map(|s| s.to_string()),
+        format_override: None,
+    };
+
+    let xml_files = convert::find_sf_xml_files(&opts);
+    let root = convert::common_root_from_opts(&opts);
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cfg = config::load_config(&cwd).unwrap_or_default();
+
+    let mut result = DiffResult {
+        new_files: Vec::new(),
+        modified_files: Vec::new(),
+        deleted_files: Vec::new(),
+        unchanged_files: 0,
+    };
+
+    // Check each XML file against its packed counterpart
+    for xml_path in &xml_files {
+        let short_type = convert::metadata_type_for(xml_path);
+        let type_name = metadata_types::manifest_type_for_short(&short_type);
+        if cfg.should_skip(&type_name) || cfg.should_skip(&short_type) {
+            continue;
+        }
+
+        let format = convert::effective_format_for(&short_type, &type_name, &cfg, &None);
+        let ext = if format == "json" { "json" } else { "yaml" };
+        let compact_path = convert::compact_path_for(xml_path, &root, packed_dir, ext);
+
+        let relative = xml_path
+            .strip_prefix(&root)
+            .unwrap_or(xml_path)
+            .display()
+            .to_string();
+
+        if !compact_path.exists() {
+            result.new_files.push(relative);
+            continue;
+        }
+
+        // Generate fresh compact content and compare
+        let xml_content = fs::read_to_string(xml_path)
+            .with_context(|| format!("Reading {}", xml_path.display()))?;
+        let node = xml_parser::parse_xml(&xml_content)
+            .with_context(|| format!("Parsing {}", xml_path.display()))?;
+
+        let fresh = if format == "json" {
+            json_writer::xml_to_json(&node)?
+        } else if format == "yaml-ordered" {
+            yaml_writer::xml_to_yaml_ordered(&node)?
+        } else {
+            yaml_writer::xml_to_yaml(&node)?
+        };
+
+        let existing = fs::read_to_string(&compact_path)
+            .with_context(|| format!("Reading {}", compact_path.display()))?;
+
+        if fresh.trim() != existing.trim() {
+            result.modified_files.push(relative);
+        } else {
+            result.unchanged_files += 1;
+        }
+    }
+
+    // Check for deleted files (packed files with no corresponding XML)
+    if packed_dir.exists() {
+        let packed_opts = convert::ConvertOpts {
+            paths: vec![packed_dir.to_path_buf()],
+            include: include.map(|s| s.to_string()),
+            format_override: None,
+        };
+        let compact_files = convert::find_compact_files(&packed_opts);
+        let packed_root = packed_dir.to_path_buf();
+
+        for compact_path in &compact_files {
+            let relative = compact_path
+                .strip_prefix(&packed_root)
+                .unwrap_or(compact_path);
+            let xml_name = relative
+                .to_string_lossy()
+                .replace("-meta.yaml", "-meta.xml")
+                .replace("-meta.json", "-meta.xml");
+
+            // Check if any source contains this XML
+            let found = sources.iter().any(|src| src.join(&xml_name).exists());
+            if !found {
+                result
+                    .deleted_files
+                    .push(compact_path.display().to_string());
+            }
+        }
+    }
+
+    Ok(result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 mod config;
 mod convert;
+mod diff;
 mod json_writer;
 mod manifest;
 mod mcp;
 mod metadata_types;
+mod watch;
 mod xml_parser;
 mod yaml_writer;
 
@@ -79,6 +81,38 @@ enum Commands {
     Init {
         #[command(subcommand)]
         mode: InitMode,
+    },
+    /// Watch source directories and auto-pack on XML changes
+    Watch {
+        /// Source path: directory or specific file(s)
+        #[arg(default_value = "force-app")]
+        source: Vec<PathBuf>,
+
+        /// Output directory for compact files
+        #[arg(short, long, default_value = ".sf-compact")]
+        output: PathBuf,
+
+        /// Only include files matching this glob pattern
+        #[arg(long)]
+        include: Option<String>,
+
+        /// Output format override (yaml, yaml-ordered, or json)
+        #[arg(long)]
+        format: Option<String>,
+    },
+    /// Show which XML files changed since last pack
+    Diff {
+        /// Source path: directory or specific file(s)
+        #[arg(default_value = "force-app")]
+        source: Vec<PathBuf>,
+
+        /// Packed directory to compare against
+        #[arg(short, long, default_value = ".sf-compact")]
+        output: PathBuf,
+
+        /// Only include files matching this glob pattern
+        #[arg(long)]
+        include: Option<String>,
     },
     /// Manage .sfcompact.yaml configuration
     Config {
@@ -229,6 +263,50 @@ fn main() -> Result<()> {
                         fi.relative_path, fi.original_tokens, fi.compact_tokens
                     );
                 }
+            }
+        }
+        Commands::Watch {
+            source,
+            output,
+            include,
+            format,
+        } => {
+            watch::watch(&source, &output, include, format)?;
+        }
+        Commands::Diff {
+            source,
+            output,
+            include,
+        } => {
+            let result = diff::diff(&source, &output, include.as_deref())?;
+
+            let total_changes =
+                result.new_files.len() + result.modified_files.len() + result.deleted_files.len();
+
+            if total_changes == 0 {
+                println!(
+                    "No changes detected ({} files up to date)",
+                    result.unchanged_files
+                );
+            } else {
+                for f in &result.new_files {
+                    println!("  + {f}  (new — not yet packed)");
+                }
+                for f in &result.modified_files {
+                    println!("  ~ {f}  (modified since last pack)");
+                }
+                for f in &result.deleted_files {
+                    println!("  - {f}  (packed file has no source XML)");
+                }
+                println!();
+                println!(
+                    "{} new, {} modified, {} deleted, {} unchanged",
+                    result.new_files.len(),
+                    result.modified_files.len(),
+                    result.deleted_files.len(),
+                    result.unchanged_files,
+                );
+                println!("Run `sf-compact pack` to update.");
             }
         }
         Commands::McpServe => {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -307,6 +307,18 @@ sf-compact config skip customMetadata               # exclude a type
 sf-compact config show                              # display config
 ```
 
+### Watch (auto-pack on changes)
+```bash
+sf-compact watch [source...] [-o output] [--format yaml|yaml-ordered|json]
+```
+Watches source directories and auto-repacks when XML files change.
+
+### Diff (detect unpacked changes)
+```bash
+sf-compact diff [source...] [-o packed-dir]
+```
+Shows which XML files have changed since last pack (new, modified, deleted).
+
 ### Other Commands
 - `sf-compact manifest` — output supported metadata types in JSON
 - `sf-compact mcp-serve` — start MCP server over stdio

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,99 @@
+use anyhow::{Context, Result};
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::convert;
+
+/// Watch source directories for XML changes and auto-pack.
+pub fn watch(
+    sources: &[PathBuf],
+    output: &Path,
+    include: Option<String>,
+    format_override: Option<String>,
+) -> Result<()> {
+    // Validate paths exist
+    for p in sources {
+        if !p.exists() {
+            anyhow::bail!("Path not found: {}", p.display());
+        }
+    }
+
+    // Initial pack
+    let opts = convert::ConvertOpts {
+        paths: sources.to_vec(),
+        include: include.clone(),
+        format_override: format_override.clone(),
+    };
+    let stats = convert::pack(&opts, output)?;
+    eprintln!(
+        "Initial pack: {} files, {} → {} bytes ({:.1}% reduction)",
+        stats.files_processed,
+        stats.original_bytes,
+        stats.compact_bytes,
+        stats.reduction_percent(),
+    );
+
+    let (tx, rx) = mpsc::channel();
+
+    let mut debouncer =
+        new_debouncer(Duration::from_millis(500), tx).context("Failed to create file watcher")?;
+
+    for source in sources {
+        debouncer
+            .watcher()
+            .watch(source, notify::RecursiveMode::Recursive)
+            .with_context(|| format!("Failed to watch {}", source.display()))?;
+    }
+
+    eprintln!(
+        "Watching {} for changes... (Ctrl+C to stop)",
+        sources
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    loop {
+        match rx.recv() {
+            Ok(Ok(events)) => {
+                // Check if any event is relevant (SF metadata XML files)
+                let has_xml_change = events.iter().any(|e| {
+                    e.kind == DebouncedEventKind::Any
+                        && e.path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|n| n.ends_with("-meta.xml") || n.ends_with(".xml"))
+                });
+
+                if has_xml_change {
+                    let opts = convert::ConvertOpts {
+                        paths: sources.to_vec(),
+                        include: include.clone(),
+                        format_override: format_override.clone(),
+                    };
+                    match convert::pack(&opts, output) {
+                        Ok(stats) => {
+                            eprintln!(
+                                "Repacked {} files ({:.1}% reduction)",
+                                stats.files_processed,
+                                stats.reduction_percent(),
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("Pack error: {e}");
+                        }
+                    }
+                }
+            }
+            Ok(Err(err)) => {
+                eprintln!("Watch error: {err}");
+            }
+            Err(e) => {
+                anyhow::bail!("Watch channel closed: {e}");
+            }
+        }
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1256,6 +1256,159 @@ fn unpack_skips_invalid_sf_compact_files() {
     );
 }
 
+// ─── Diff tests ─────────────────────────────────────────────────
+
+#[test]
+fn diff_shows_no_changes_after_pack() {
+    let fixtures = Path::new("tests/fixtures");
+    let packed = tempfile::tempdir().unwrap();
+
+    // Pack first
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pack");
+    assert!(output.status.success());
+
+    // Diff should show no changes
+    let output = sf_compact()
+        .args([
+            "diff",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to diff");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No changes"),
+        "should show no changes after fresh pack, got: {stdout}"
+    );
+}
+
+#[test]
+fn diff_detects_new_files() {
+    let packed = tempfile::tempdir().unwrap();
+
+    // Don't pack anything — all files should be "new"
+    let output = sf_compact()
+        .args([
+            "diff",
+            "tests/fixtures",
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to diff");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("new"),
+        "should show new files when nothing packed, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Run `sf-compact pack`"),
+        "should suggest running pack, got: {stdout}"
+    );
+}
+
+#[test]
+fn diff_detects_modified_files() {
+    let fixtures = Path::new("tests/fixtures");
+    let packed = tempfile::tempdir().unwrap();
+
+    // Pack first
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pack");
+    assert!(output.status.success());
+
+    // Corrupt a packed file to simulate stale pack
+    let profile_yaml = packed
+        .path()
+        .join("force-app/main/default/profiles/Admin.profile-meta.yaml");
+    assert!(profile_yaml.exists());
+    std::fs::write(&profile_yaml, "# corrupted\n").unwrap();
+
+    // Diff should detect the modification
+    let output = sf_compact()
+        .args([
+            "diff",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to diff");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("modified"),
+        "should detect modified file, got: {stdout}"
+    );
+}
+
+// ─── Unpack --include test ──────────────────────────────────────
+
+#[test]
+fn unpack_with_include_filter() {
+    let fixtures = Path::new("tests/fixtures");
+    let packed = tempfile::tempdir().unwrap();
+    let unpacked = tempfile::tempdir().unwrap();
+
+    // Pack everything first
+    let output = sf_compact()
+        .args([
+            "pack",
+            fixtures.to_str().unwrap(),
+            "-o",
+            packed.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to pack");
+    assert!(output.status.success());
+
+    // Unpack only profiles
+    let output = sf_compact()
+        .args([
+            "unpack",
+            packed.path().to_str().unwrap(),
+            "-o",
+            unpacked.path().to_str().unwrap(),
+            "--include",
+            "*.profile-meta.yaml",
+        ])
+        .output()
+        .expect("failed to unpack with --include");
+    assert!(
+        output.status.success(),
+        "unpack with --include failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Unpacked 1 files"),
+        "should unpack only 1 profile, got: {stdout}"
+    );
+}
+
 /// Helper to recursively copy a directory.
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
     std::fs::create_dir_all(dst).unwrap();


### PR DESCRIPTION
## Summary
- **`sf-compact watch`** — monitors source directories for XML changes and auto-repacks (uses `notify` crate with 500ms debounce)
- **`sf-compact diff`** — compares current XML metadata against packed output, shows new/modified/deleted files
- **Verified `unpack --include`** — glob filter already worked for unpack, added integration test
- Updated README and MCP instructions with new commands
- Removed "coming soon" from crates.io install section

35 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)